### PR TITLE
Improved image tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,4 @@ ignore = [
 "**/tests/**/*" = ["N802"]
 
 [tool.pytest.ini_options]
-filterwarnings = ["ignore::DeprecationWarning"]
+filterwarnings = ["ignore::DeprecationWarning", "ignore::UserWarning"]

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.Compact import SRVGGNetCompact
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_Compact_realesr_general_x4v3(snapshot):
@@ -11,10 +11,10 @@ def test_Compact_realesr_general_x4v3(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SRVGGNetCompact)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -25,8 +25,8 @@ def test_Compact_community(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SRVGGNetCompact)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.ESRGAN import RRDBNet
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_ESRGAN_community(snapshot):
@@ -11,10 +11,10 @@ def test_ESRGAN_community(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -25,10 +25,10 @@ def test_BSRGAN(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -39,10 +39,10 @@ def test_BSRGAN_2x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -53,10 +53,10 @@ def test_RealSR_DPED(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -67,10 +67,10 @@ def test_RealSR_JPEG(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -81,10 +81,10 @@ def test_RealESRGAN_x4plus(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -95,10 +95,10 @@ def test_RealESRGAN_x2plus(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -109,10 +109,10 @@ def test_RealESRGAN_x4plus_anime_6B(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -123,8 +123,8 @@ def test_RealESRNet_x4plus(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )

--- a/tests/test_HAT.py
+++ b/tests/test_HAT.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.HAT import HAT
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_HAT_community1(snapshot):
@@ -11,10 +11,10 @@ def test_HAT_community1(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, HAT)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.OmniSR import OmniSR
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_OmniSR_community1(snapshot):
@@ -11,10 +11,10 @@ def test_OmniSR_community1(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, OmniSR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -25,8 +25,8 @@ def test_OmniSR_community2(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, OmniSR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.SwiftSRGAN import SwiftSRGAN
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_SwiftSRGan_2x(snapshot):
@@ -11,10 +11,10 @@ def test_SwiftSRGan_2x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwiftSRGAN)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -25,8 +25,8 @@ def test_SwiftSRGan_4x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwiftSRGAN)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )

--- a/tests/test_Swin2SR.py
+++ b/tests/test_Swin2SR.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.Swin2SR import Swin2SR
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_Swin2SR_4x(snapshot):
@@ -11,8 +11,8 @@ def test_Swin2SR_4x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, Swin2SR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )

--- a/tests/test_SwinIR.py
+++ b/tests/test_SwinIR.py
@@ -1,7 +1,7 @@
 from spandrel import ModelLoader
 from spandrel.architectures.SwinIR import SwinIR
 
-from .util import ImageTestNames, ModelFile, compare_images_to_results, disallowed_props
+from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
 
 
 def test_SwinIR_M_s64w8_2x(snapshot):
@@ -11,10 +11,10 @@ def test_SwinIR_M_s64w8_2x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -25,10 +25,10 @@ def test_SwinIR_M_s48w8_4x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -39,10 +39,10 @@ def test_SwinIR_S_2x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )
 
 
@@ -53,8 +53,8 @@ def test_SwinIR_L_4x(snapshot):
     model = ModelLoader().load_from_file(file.path)
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
-    assert compare_images_to_results(
-        file.name,
-        model.model,
-        [ImageTestNames.SR_16, ImageTestNames.SR_32, ImageTestNames.SR_64],
+    assert_image_inference(
+        file,
+        model,
+        [TestImage.SR_16, TestImage.SR_32, TestImage.SR_64],
     )


### PR DESCRIPTION
Changes:
- Ignore torch deprecation warnings.
- Renamed some functions.
- `assert_image_inference` now checks that the model output channels and scale are correct.
- `assert_image_inference` now writes inference outputs to disk (if different or non-existent) with the `--snapshot-update` flag, just like other snapshots.