### PR TITLE
Improved parameter detection for Compact

### DIFF
--- a/src/spandrel/architectures/Compact/__init__.py
+++ b/src/spandrel/architectures/Compact/__init__.py
@@ -3,46 +3,57 @@ from __future__ import annotations
 import math
 
 from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ..__arch_helpers.state import get_max_seq_index
 from .arch.SRVGG import SRVGGNetCompact
 
 
-def _get_num_conv(highest_num: int) -> int:
-    return (highest_num - 2) // 2
+def _get_scale_and_output_channels(x: int, input_channels: int) -> tuple[int, int]:
+    # Unfortunately, we do not have enough information to determine both the scale and
+    # number output channels correctly *in general*. However, we can make some
+    # assumptions to make it good enough.
+    #
+    # What we know:
+    # - x = scale * scale * output_channels
+    # - output_channels is likely equal to input_channels
+    # - output_channels and input_channels is likely 1, 3, or 4
+    # - scale is likely 1, 2, 4, or 8
 
+    def is_square(n: int) -> bool:
+        return math.sqrt(n) == int(math.sqrt(n))
 
-def _get_num_feats(state: StateDict, weight_keys: list[str]) -> int:
-    return state[weight_keys[0]].shape[0]
+    def perfect_square_root(n: int) -> int:
+        root = int(math.sqrt(n))
+        assert root * root == n, f"{n} is not a perfect square"
+        return root
 
+    if x % 3 == 0 and x % 9 != 0:
+        # we know that output_channels MUST be a multiple of 3
+        # so let's assume that output_channels is exactly 3
+        x = x // 3
+        return perfect_square_root(x), 3
 
-def _get_in_nc(state: StateDict, weight_keys: list[str]) -> int:
-    return state[weight_keys[0]].shape[1]
+    # just try out a few candidates and see which ones fulfill the requirements
+    candidates = [input_channels, 3, 4, 1]
+    for c in candidates:
+        if x % c == 0 and is_square(x // c):
+            return perfect_square_root(x // c), c
 
-
-def _get_scale(pixelshuffle_shape: int, out_nc: int) -> int:
-    scale = math.sqrt(pixelshuffle_shape / out_nc)
-    if scale - int(scale) > 0:
-        print(
-            "out_nc is probably different than in_nc, scale calculation might be wrong"
-        )
-    scale = int(scale)
-    return scale
+    raise AssertionError(
+        f"Expected output channels to be either 1, 3, or 4. Could not find a a pair (s, o) such that s*s*o = {x}"
+    )
 
 
 def load(state_dict: StateDict) -> SRModelDescriptor[SRVGGNetCompact]:
     state = state_dict
 
-    weight_keys = [key for key in state.keys() if "weight" in key]
-    highest_num = max([int(key.split(".")[1]) for key in weight_keys if "body" in key])
+    highest_num = get_max_seq_index(state, "body.{}.weight")
 
-    in_nc = _get_in_nc(state, weight_keys)
-    num_feat = _get_num_feats(state, weight_keys)
-    num_conv = _get_num_conv(highest_num)
-    # Assume out_nc is the same as in_nc
-    # I cant think of a better way to do that
-    out_nc = in_nc  # :(
+    in_nc = state["body.0.weight"].shape[1]
+    num_feat = state["body.0.weight"].shape[0]
+    num_conv = (highest_num - 2) // 2
 
     pixelshuffle_shape = state[f"body.{highest_num}.bias"].shape[0]
-    scale = _get_scale(pixelshuffle_shape, out_nc)
+    scale, out_nc = _get_scale_and_output_channels(pixelshuffle_shape, in_nc)
 
     model = SRVGGNetCompact(
         num_in_ch=in_nc,
@@ -50,7 +61,6 @@ def load(state_dict: StateDict) -> SRModelDescriptor[SRVGGNetCompact]:
         num_feat=num_feat,
         num_conv=num_conv,
         upscale=scale,
-        pixelshuffle_shape=pixelshuffle_shape,
     )
 
     tags = [f"{num_feat}nf", f"{num_conv}nc"]

--- a/src/spandrel/architectures/Compact/__init__.py
+++ b/src/spandrel/architectures/Compact/__init__.py
@@ -21,22 +21,11 @@ def _get_scale_and_output_channels(x: int, input_channels: int) -> tuple[int, in
     def is_square(n: int) -> bool:
         return math.sqrt(n) == int(math.sqrt(n))
 
-    def perfect_square_root(n: int) -> int:
-        root = int(math.sqrt(n))
-        assert root * root == n, f"{n} is not a perfect square"
-        return root
-
-    if x % 3 == 0 and x % 9 != 0:
-        # we know that output_channels MUST be a multiple of 3
-        # so let's assume that output_channels is exactly 3
-        x = x // 3
-        return perfect_square_root(x), 3
-
     # just try out a few candidates and see which ones fulfill the requirements
     candidates = [input_channels, 3, 4, 1]
     for c in candidates:
         if x % c == 0 and is_square(x // c):
-            return perfect_square_root(x // c), c
+            return int(math.sqrt(x // c)), c
 
     raise AssertionError(
         f"Expected output channels to be either 1, 3, or 4. Could not find a a pair (s, o) such that s*s*o = {x}"

--- a/src/spandrel/architectures/Compact/__init__.py
+++ b/src/spandrel/architectures/Compact/__init__.py
@@ -29,7 +29,7 @@ def _get_scale_and_output_channels(x: int, input_channels: int) -> tuple[int, in
 
     raise AssertionError(
         f"Expected output channels to be either 1, 3, or 4."
-        f" Could not find a pair (s, o) such that s*s*o = {x}"
+        f" Could not find a pair (scale, out_nc) such that `scale**2 * out_nc = {x}`"
     )
 
 

--- a/src/spandrel/architectures/Compact/__init__.py
+++ b/src/spandrel/architectures/Compact/__init__.py
@@ -28,7 +28,8 @@ def _get_scale_and_output_channels(x: int, input_channels: int) -> tuple[int, in
             return int(math.sqrt(x // c)), c
 
     raise AssertionError(
-        f"Expected output channels to be either 1, 3, or 4. Could not find a a pair (s, o) such that s*s*o = {x}"
+        f"Expected output channels to be either 1, 3, or 4."
+        f" Could not find a pair (s, o) such that s*s*o = {x}"
     )
 
 

--- a/src/spandrel/architectures/KBNet/__init__.py
+++ b/src/spandrel/architectures/KBNet/__init__.py
@@ -5,24 +5,11 @@ from ...__helpers.model_descriptor import (
     SizeRequirements,
     StateDict,
 )
+from ..__arch_helpers.state import get_max_seq_index
 from .arch.kbnet_l import KBNet_l
 from .arch.kbnet_s import KBNet_s
 
 # KBCNN is essentially 2 similar but different architectures: KBNet_l and KBNet_s.
-
-
-def _get_max_seq(state: StateDict, key_pattern: str, start: int = 0) -> int:
-    """
-    Returns the maximum number `i` such that `key_pattern.format(str(i))` is in `state`.
-
-    If no such key is in state, then `start - 1` is returned.
-    """
-    i = start
-    while True:
-        key = key_pattern.format(str(i))
-        if key not in state:
-            return i - 1
-        i += 1
 
 
 def load_l(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_l]:
@@ -40,12 +27,14 @@ def load_l(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_l]:
 
     dim = state_dict["patch_embed.proj.weight"].shape[0]
 
-    num_blocks[0] = _get_max_seq(state_dict, "encoder_level1.{}.norm1.weight") + 1
-    num_blocks[1] = _get_max_seq(state_dict, "encoder_level2.{}.norm1.weight") + 1
-    num_blocks[2] = _get_max_seq(state_dict, "encoder_level3.{}.norm1.weight") + 1
-    num_blocks[3] = _get_max_seq(state_dict, "latent.{}.norm1.weight") + 1
+    num_blocks[0] = get_max_seq_index(state_dict, "encoder_level1.{}.norm1.weight") + 1
+    num_blocks[1] = get_max_seq_index(state_dict, "encoder_level2.{}.norm1.weight") + 1
+    num_blocks[2] = get_max_seq_index(state_dict, "encoder_level3.{}.norm1.weight") + 1
+    num_blocks[3] = get_max_seq_index(state_dict, "latent.{}.norm1.weight") + 1
 
-    num_refinement_blocks = _get_max_seq(state_dict, "refinement.{}.norm1.weight") + 1
+    num_refinement_blocks = (
+        get_max_seq_index(state_dict, "refinement.{}.norm1.weight") + 1
+    )
 
     heads[0] = state_dict["encoder_level1.0.ffn.temperature"].shape[0]
     heads[1] = state_dict["encoder_level2.0.ffn.temperature"].shape[0]
@@ -98,17 +87,21 @@ def load_s(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_s]:
     img_channel = state_dict["intro.weight"].shape[1]
     width = state_dict["intro.weight"].shape[0]
 
-    middle_blk_num = _get_max_seq(state_dict, "middle_blks.{}.w") + 1
+    middle_blk_num = get_max_seq_index(state_dict, "middle_blks.{}.w") + 1
 
-    enc_count = _get_max_seq(state_dict, "encoders.{}.0.w") + 1
+    enc_count = get_max_seq_index(state_dict, "encoders.{}.0.w") + 1
     enc_blk_nums = [1] * enc_count
     for i in range(enc_count):
-        enc_blk_nums[i] = _get_max_seq(state_dict, "encoders." + str(i) + ".{}.w") + 1
+        enc_blk_nums[i] = (
+            get_max_seq_index(state_dict, "encoders." + str(i) + ".{}.w") + 1
+        )
 
-    dec_count = _get_max_seq(state_dict, "decoders.{}.0.w") + 1
+    dec_count = get_max_seq_index(state_dict, "decoders.{}.0.w") + 1
     dec_blk_nums = [1] * dec_count
     for i in range(dec_count):
-        dec_blk_nums[i] = _get_max_seq(state_dict, "decoders." + str(i) + ".{}.w") + 1
+        dec_blk_nums[i] = (
+            get_max_seq_index(state_dict, "decoders." + str(i) + ".{}.w") + 1
+        )
 
     # in code: ffn_ch = int(c * ffn_scale)
     temp_c = state_dict["middle_blks.0.conv4.weight"].shape[1]

--- a/src/spandrel/architectures/__arch_helpers/state.py
+++ b/src/spandrel/architectures/__arch_helpers/state.py
@@ -1,0 +1,20 @@
+def get_max_seq_index(state: dict, key_pattern: str, start: int = 0) -> int:
+    """
+    Returns the maximum number `i` such that `key_pattern.format(str(i))` is in `state`.
+
+    This is useful for detecting the number of elements in a sequence. Since this
+    function returns the highest index, the length of the sequence is simply
+    `get_max_seq_index(state, pattern) + 1`. This even correctly accounts for empty
+    sequences.
+
+    If no such key is in state, then `start - 1` is returned.
+
+    Example:
+        get_max_seq_index(state, "body.{}.weight") -> 5
+    """
+    i = start
+    while True:
+        key = key_pattern.format(str(i))
+        if key not in state:
+            return i - 1
+        i += 1

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -1,7 +1,34 @@
 from spandrel import ModelLoader
-from spandrel.architectures.Compact import SRVGGNetCompact
+from spandrel.architectures.Compact import SRVGGNetCompact, load
 
-from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
+from .util import (
+    ModelFile,
+    TestImage,
+    assert_image_inference,
+    assert_loads_correctly,
+    disallowed_props,
+)
+
+
+def test_Compact_load():
+    assert_loads_correctly(
+        load,
+        lambda: SRVGGNetCompact(),
+        lambda: SRVGGNetCompact(num_in_ch=1, num_out_ch=1),
+        lambda: SRVGGNetCompact(num_in_ch=3, num_out_ch=3),
+        lambda: SRVGGNetCompact(num_in_ch=4, num_out_ch=4),
+        lambda: SRVGGNetCompact(num_in_ch=1, num_out_ch=3),
+        lambda: SRVGGNetCompact(num_feat=32),
+        lambda: SRVGGNetCompact(num_conv=5),
+        lambda: SRVGGNetCompact(upscale=3),
+        condition=lambda a, b: (
+            a.upscale == b.upscale
+            and a.num_in_ch == b.num_in_ch
+            and a.num_out_ch == b.num_out_ch
+            and a.num_feat == b.num_feat
+            and a.num_conv == b.num_conv
+        ),
+    )
 
 
 def test_Compact_realesr_general_x4v3(snapshot):


### PR DESCRIPTION
Changes:
- Removed the `pixelshuffle_shape` parameter. We are now using the exact model code from the Real-ESRGAN repo.
- Improved detection of output channels and scale. We now support grayscale to RGB compact models.
- Added tests to verify the new detection code.

The new detection code is actually pretty simple: we just brute force it. We know that the number `x` we read from the state dict is `x = scale * scale * out_nc`. We also know that `out_nc` is either 1, 3, or 4. So we just have to try out all possible values for `out_nc` see which one fulfills the formula for `x`.

Unfortunately, this method does not work correctly when the actual number of output channels is 1 or 4, because 1 and 4 are square numbers. E.g. for `scale=3` and `out__nc=4` we get `x=36`, but `scale=6` and `out_nc=1` also produces `x=36`. To fix this, we make the assumption that `out_nc=in_nc` is *likely*. E.g. if `in_nc=4`, we will *prefer* `out_nc=4` over `out_nc=1`.
