### PR TITLE
Central function to canonicalize state dicts

### DIFF
--- a/scripts/dump_state_dict.py
+++ b/scripts/dump_state_dict.py
@@ -52,20 +52,14 @@ from torch import Tensor
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
 from spandrel import ModelLoader  # noqa: E402
+from spandrel.__helpers.canonicalize import canonicalize_state_dict  # noqa: E402
 
 State = Dict[str, object]
 
 
 def load_state(file: str) -> State:
     state_dict = ModelLoader().load_state_dict_from_file(file)
-
-    unwrap_keys = ["params_ema", "params-ema", "params", "model", "net"]
-    for unwrap_key in unwrap_keys:
-        if unwrap_key in state_dict and isinstance(state_dict[unwrap_key], dict):
-            state_dict = state_dict[unwrap_key]
-            break
-
-    return state_dict
+    return canonicalize_state_dict(state_dict)
 
 
 def indent(lines: list[str], indentation: str = "  "):

--- a/scripts/dump_state_dict.py
+++ b/scripts/dump_state_dict.py
@@ -51,14 +51,13 @@ from torch import Tensor
 # This hack is necessary to make our module import
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from spandrel import ModelLoader, canonicalize_state_dict  # noqa: E402
+from spandrel import ModelLoader  # noqa: E402
 
 State = Dict[str, object]
 
 
 def load_state(file: str) -> State:
-    state_dict = ModelLoader().load_state_dict_from_file(file)
-    return canonicalize_state_dict(state_dict)
+    return ModelLoader().load_state_dict_from_file(file)
 
 
 def indent(lines: list[str], indentation: str = "  "):

--- a/scripts/dump_state_dict.py
+++ b/scripts/dump_state_dict.py
@@ -51,8 +51,7 @@ from torch import Tensor
 # This hack is necessary to make our module import
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from spandrel import ModelLoader  # noqa: E402
-from spandrel.__helpers.canonicalize import canonicalize_state_dict  # noqa: E402
+from spandrel import ModelLoader, canonicalize_state_dict  # noqa: E402
 
 State = Dict[str, object]
 

--- a/src/spandrel/__helpers/canonicalize.py
+++ b/src/spandrel/__helpers/canonicalize.py
@@ -1,0 +1,27 @@
+from .model_descriptor import StateDict
+
+
+def canonicalize_state_dict(state_dict: StateDict) -> StateDict:
+    """
+    Canonicalize a state dict.
+
+    This function is used to canonicalize a state dict, so that it can be
+    compared to other state dicts. This is useful for testing, as it allows us
+    to compare the state dict of a model to a snapshot of the state dict.
+
+    This function is not intended to be used in production code.
+    """
+
+    # the real state dict might be inside a dict with a known key
+    unwrap_keys = ["state_dict", "params_ema", "params-ema", "params", "model", "net"]
+    for unwrap_key in unwrap_keys:
+        if unwrap_key in state_dict and isinstance(state_dict[unwrap_key], dict):
+            state_dict = state_dict[unwrap_key]
+            break
+
+    # remove known common prefixes
+    for prefix in ["module.", "netG."]:
+        if all(i.startswith(prefix) for i in state_dict.keys()):
+            state_dict = {k[len(prefix) :]: v for k, v in state_dict.items()}
+
+    return state_dict

--- a/src/spandrel/__helpers/canonicalize.py
+++ b/src/spandrel/__helpers/canonicalize.py
@@ -6,8 +6,7 @@ def canonicalize_state_dict(state_dict: StateDict) -> StateDict:
     Canonicalize a state dict.
 
     This function is used to canonicalize a state dict, so that it can be
-    compared to other state dicts. This is useful for testing, as it allows us
-    to compare the state dict of a model to a snapshot of the state dict.
+    used for architecture detection and loading.
 
     This function is not intended to be used in production code.
     """
@@ -20,8 +19,9 @@ def canonicalize_state_dict(state_dict: StateDict) -> StateDict:
             break
 
     # remove known common prefixes
-    for prefix in ["module.", "netG."]:
-        if all(i.startswith(prefix) for i in state_dict.keys()):
-            state_dict = {k[len(prefix) :]: v for k, v in state_dict.items()}
+    if len(state_dict) > 0:
+        for prefix in ["module.", "netG."]:
+            if all(i.startswith(prefix) for i in state_dict.keys()):
+                state_dict = {k[len(prefix) :]: v for k, v in state_dict.items()}
 
     return state_dict

--- a/src/spandrel/__helpers/loader.py
+++ b/src/spandrel/__helpers/loader.py
@@ -90,19 +90,8 @@ class ModelLoader:
         return load_file(path, device=str(self.device))
 
     def _load_ckpt(self, path: str | Path) -> StateDict:
-        checkpoint = torch.load(
+        return torch.load(
             path,
             map_location=self.device,
             pickle_module=RestrictedUnpickle,  # type: ignore
         )
-        if "state_dict" in checkpoint:
-            checkpoint = checkpoint["state_dict"]
-        state_dict = {}
-        for i, j in checkpoint.items():
-            if "netG." in i:
-                key = i.replace("netG.", "")
-                state_dict[key] = j
-            elif "module." in i:
-                key = i.replace("module.", "")
-                state_dict[key] = j
-        return state_dict

--- a/src/spandrel/__helpers/loader.py
+++ b/src/spandrel/__helpers/loader.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import torch
 from safetensors.torch import load_file
 
+from .canonicalize import canonicalize_state_dict
 from .main_registry import MAIN_REGISTRY
 from .model_descriptor import ModelDescriptor, StateDict
 from .registry import ArchRegistry
@@ -52,18 +53,21 @@ class ModelLoader:
 
         extension = os.path.splitext(path)[1].lower()
 
+        state_dict: StateDict
         if extension == ".pt":
-            return self._load_torchscript(path)
+            state_dict = self._load_torchscript(path)
         elif extension == ".pth":
-            return self._load_pth(path)
+            state_dict = self._load_pth(path)
         elif extension == ".ckpt":
-            return self._load_ckpt(path)
+            state_dict = self._load_ckpt(path)
         elif extension == ".safetensors":
-            return self._load_safetensors(path)
+            state_dict = self._load_safetensors(path)
         else:
             raise ValueError(
                 f"Unsupported model file extension {extension}. Please try a supported model type."
             )
+
+        return canonicalize_state_dict(state_dict)
 
     def load_from_state_dict(self, state_dict: StateDict) -> ModelDescriptor:
         """

--- a/src/spandrel/__helpers/main_registry.py
+++ b/src/spandrel/__helpers/main_registry.py
@@ -181,14 +181,6 @@ MAIN_REGISTRY.add(
                 "decoders.0.0.attgamma",
                 "ending.weight",
             )(state)
-            # some KBNet_s models are prefixed with "module." for some reason
-            or _has_keys(
-                "module.intro.weight",
-                "module.encoders.0.0.attgamma",
-                "module.middle_blks.0.w",
-                "module.decoders.0.0.attgamma",
-                "module.ending.weight",
-            )(state)
             # KBNet_l
             or _has_keys(
                 "patch_embed.proj.weight",

--- a/src/spandrel/__helpers/registry.py
+++ b/src/spandrel/__helpers/registry.py
@@ -147,6 +147,8 @@ class ArchRegistry:
         """
         Detects the architecture of the given state dict and loads it.
 
+        This will canonicalize the state dict if it isn't already.
+
         Throws an `UnsupportedModelError` if the model architecture is not supported.
         """
 

--- a/src/spandrel/__helpers/registry.py
+++ b/src/spandrel/__helpers/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Literal
 
+from .canonicalize import canonicalize_state_dict
 from .model_descriptor import ModelDescriptor, StateDict
 
 
@@ -149,11 +150,7 @@ class ArchRegistry:
         Throws an `UnsupportedModelError` if the model architecture is not supported.
         """
 
-        unwrap_keys = ["params_ema", "params-ema", "params", "model", "net"]
-        for unwrap_key in unwrap_keys:
-            if unwrap_key in state_dict and isinstance(state_dict[unwrap_key], dict):
-                state_dict = state_dict[unwrap_key]
-                break
+        state_dict = canonicalize_state_dict(state_dict)
 
         for arch in self._ordered:
             if arch.detect(state_dict):

--- a/src/spandrel/__init__.py
+++ b/src/spandrel/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.0.3"
 
+from .__helpers.canonicalize import canonicalize_state_dict
 from .__helpers.loader import ModelLoader
 from .__helpers.main_registry import MAIN_REGISTRY
 from .__helpers.model_descriptor import (
@@ -17,13 +18,14 @@ from .__helpers.registry import ArchRegistry, ArchSupport, UnsupportedModelError
 __all__ = [
     "ArchRegistry",
     "ArchSupport",
-    "RestorationModelDescriptor",
+    "canonicalize_state_dict",
     "FaceSRModelDescriptor",
     "InpaintModelDescriptor",
     "MAIN_REGISTRY",
     "ModelBase",
     "ModelDescriptor",
     "ModelLoader",
+    "RestorationModelDescriptor",
     "SizeRequirements",
     "SRModelDescriptor",
     "StateDict",

--- a/src/spandrel/architectures/KBNet/__init__.py
+++ b/src/spandrel/architectures/KBNet/__init__.py
@@ -70,10 +70,6 @@ def load_l(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_l]:
 
 
 def load_s(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_s]:
-    # remove module. prefix
-    if "module.intro.weight" in state_dict:
-        state_dict = {k.replace("module.", "", 1): v for k, v in state_dict.items()}
-
     img_channel = 3
     width = 64
     middle_blk_num = 12


### PR DESCRIPTION
I wanted to add support for another arch today and noticed the pretrained models are checkpoints saved as `.pth` files. Since they are `.pth` files, our code for simplifying `.ckpt` files does not run, and the loaded state dict is a mess.

So I combined the code for cleaning up `.ckpt` files and the code for unwrapping nested dicts into one function: `canonicalize_state_dict`. The job of this function to bring all state dicts into a common form. 

**Open question:** Should this function be public? The `load` functions of individual archs expect a canonicalized state dict, so users **must** go through an `ArchRegistry` if they load `.pth` (or similar) files themselves. Passing `model.state_dict()` into a `load` function will continue to work though.