### PR TITLE
Fixed `ModelDescriptor` type

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generic, TypeVar, Union
 
 import torch
 
-T = TypeVar("T", bound=torch.nn.Module)
+T = TypeVar("T", bound=torch.nn.Module, covariant=True)
 
 StateDict = Dict[str, Any]
 
@@ -188,10 +188,10 @@ class RestorationModelDescriptor(ModelBase[T], Generic[T]):
 
 
 ModelDescriptor = Union[
-    SRModelDescriptor,
-    FaceSRModelDescriptor,
-    InpaintModelDescriptor,
-    RestorationModelDescriptor,
+    SRModelDescriptor[torch.nn.Module],
+    FaceSRModelDescriptor[torch.nn.Module],
+    InpaintModelDescriptor[torch.nn.Module],
+    RestorationModelDescriptor[torch.nn.Module],
 ]
 """
 A model descriptor is a loaded model with metadata. Metadata includes the

--- a/tests/util.py
+++ b/tests/util.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 from syrupy.filters import props
 
-from spandrel.__helpers.model_descriptor import ModelDescriptor, StateDict
+from spandrel.__helpers.model_descriptor import ModelBase, ModelDescriptor, StateDict
 
 MODEL_DIR = Path("./tests/models/")
 IMAGE_DIR = Path("./tests/images/")
@@ -176,7 +176,7 @@ T = TypeVar("T", bound=torch.nn.Module)
 
 
 def assert_loads_correctly(
-    load: Callable[[StateDict], ModelDescriptor],
+    load: Callable[[StateDict], ModelBase[T]],
     *models: Callable[[], T],
     condition: Callable[[T, T], bool] = lambda _a, _b: True,
 ):


### PR DESCRIPTION
The `ModelDescriptor` type was slightly broken because it didn't specify type arguments for its variants. This caused the type of `ModelDescriptor.model` to be `Unknown`. I fixed this by using `torch.nn.Module` as the type argument and making the type parameter covariant.