### PR TITLE
Improved parameter detection for SwiftSRGAN

### DIFF
--- a/src/spandrel/architectures/SwiftSRGAN/__init__.py
+++ b/src/spandrel/architectures/SwiftSRGAN/__init__.py
@@ -1,20 +1,18 @@
 from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ..__arch_helpers.state import get_seq_len
 from .arch.SwiftSRGAN import Generator as SwiftSRGAN
 
 
 def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
-    in_nc: int = state["initial.cnn.depthwise.weight"].shape[0]
-    out_nc: int = state["final_conv.pointwise.weight"].shape[0]
-    num_filters: int = state["initial.cnn.pointwise.weight"].shape[0]
-    num_blocks = len(set([x.split(".")[1] for x in state.keys() if "residual" in x]))
-    scale: int = 2 ** len(
-        set([x.split(".")[1] for x in state.keys() if "upsampler" in x])
-    )
+    in_channels: int = 3
+    num_channels: int = 64
+    num_blocks: int = 16
+    upscale_factor: int = 4
 
-    in_channels = in_nc
-    num_channels = num_filters
-    num_blocks = num_blocks
-    upscale_factor = scale
+    in_channels = state["initial.cnn.depthwise.weight"].shape[0]
+    num_channels = state["initial.cnn.pointwise.weight"].shape[0]
+    num_blocks = get_seq_len(state, "residual")
+    upscale_factor = get_seq_len(state, "upsampler") * 2
 
     model = SwiftSRGAN(
         in_channels=in_channels,
@@ -23,7 +21,7 @@ def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
         upscale_factor=upscale_factor,
     )
     tags = [
-        f"{num_filters}nf",
+        f"{num_channels}nf",
         f"{num_blocks}nb",
     ]
 
@@ -34,7 +32,7 @@ def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
         tags=tags,
         supports_half=True,
         supports_bfloat16=True,
-        scale=scale,
-        input_channels=in_nc,
-        output_channels=out_nc,
+        scale=upscale_factor,
+        input_channels=in_channels,
+        output_channels=in_channels,
     )

--- a/src/spandrel/architectures/SwiftSRGAN/__init__.py
+++ b/src/spandrel/architectures/SwiftSRGAN/__init__.py
@@ -12,7 +12,7 @@ def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
     in_channels = state["initial.cnn.depthwise.weight"].shape[0]
     num_channels = state["initial.cnn.pointwise.weight"].shape[0]
     num_blocks = get_seq_len(state, "residual")
-    upscale_factor = get_seq_len(state, "upsampler") * 2
+    upscale_factor = 2 ** get_seq_len(state, "upsampler")
 
     model = SwiftSRGAN(
         in_channels=in_channels,

--- a/src/spandrel/architectures/SwiftSRGAN/arch/SwiftSRGAN.py
+++ b/src/spandrel/architectures/SwiftSRGAN/arch/SwiftSRGAN.py
@@ -1,6 +1,8 @@
 # type: ignore
 # From https://github.com/Koushik0901/Swift-SRGAN/blob/master/swift-srgan/models.py
 
+import math
+
 import torch
 from torch import nn
 
@@ -124,7 +126,7 @@ class Generator(nn.Module):
         self.upsampler = nn.Sequential(
             *[
                 UpsampleBlock(num_channels, scale_factor=2)
-                for _ in range(upscale_factor // 2)
+                for _ in range(int(math.log2(upscale_factor)))
             ]
         )
         self.final_conv = SeperableConv2d(

--- a/tests/__snapshots__/test_SwiftSRGAN.ambr
+++ b/tests/__snapshots__/test_SwiftSRGAN.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_SwiftSRGan_2x
+# name: test_SwiftSRGAN_2x
   SRModelDescriptor(
     architecture='Swift-SRGAN',
     input_channels=3,
@@ -14,7 +14,7 @@
     ]),
   )
 # ---
-# name: test_SwiftSRGan_4x
+# name: test_SwiftSRGAN_4x
   SRModelDescriptor(
     architecture='Swift-SRGAN',
     input_channels=3,

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -1,10 +1,29 @@
 from spandrel import ModelLoader
-from spandrel.architectures.SwiftSRGAN import SwiftSRGAN
+from spandrel.architectures.SwiftSRGAN import SwiftSRGAN, load
 
-from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
+from .util import (
+    ModelFile,
+    TestImage,
+    assert_image_inference,
+    assert_loads_correctly,
+    disallowed_props,
+)
 
 
-def test_SwiftSRGan_2x(snapshot):
+def test_SwiftSRGAN_load():
+    assert_loads_correctly(
+        load,
+        lambda: SwiftSRGAN(),
+        lambda: SwiftSRGAN(in_channels=1),
+        lambda: SwiftSRGAN(num_channels=32),
+        lambda: SwiftSRGAN(num_blocks=7),
+        lambda: SwiftSRGAN(upscale_factor=2),
+        lambda: SwiftSRGAN(upscale_factor=4),
+        lambda: SwiftSRGAN(upscale_factor=8),
+    )
+
+
+def test_SwiftSRGAN_2x(snapshot):
     file = ModelFile("swift_srgan_2x.pth").download(
         "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_2x.pth.tar"
     )
@@ -18,7 +37,7 @@ def test_SwiftSRGan_2x(snapshot):
     )
 
 
-def test_SwiftSRGan_4x(snapshot):
+def test_SwiftSRGAN_4x(snapshot):
     file = ModelFile("swift_srgan_4x.pth").download(
         "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_4x.pth.tar"
     )


### PR DESCRIPTION
Changes:
- Don't detect output channels, because they are the same as the number of input channels.

I also fixed how `upscale_factor` is used in SwiftSRGAN. The bug was that they used `range(upscale_factor // 2)` when it should have been `range(log2(upscale_factor))`. The incorrect code just happened to work for 2x and 4x, but not for anything else.