### PR TITLE
Remove `get_max_seq_index`

### DIFF
--- a/src/spandrel/architectures/SCUNet/__init__.py
+++ b/src/spandrel/architectures/SCUNet/__init__.py
@@ -3,7 +3,7 @@ from ...__helpers.model_descriptor import (
     SizeRequirements,
     StateDict,
 )
-from ..__arch_helpers.state import get_max_seq_index
+from ..__arch_helpers.state import get_seq_len
 from .arch.SCUNet import SCUNet
 
 
@@ -17,13 +17,13 @@ def load(state_dict: StateDict) -> RestorationModelDescriptor[SCUNet]:
     dim = state_dict["m_head.0.weight"].shape[0]
     in_nc = state_dict["m_head.0.weight"].shape[1]
 
-    config[0] = get_max_seq_index(state_dict, "m_down1.{}.conv1_1.weight") + 1
-    config[1] = get_max_seq_index(state_dict, "m_down2.{}.conv1_1.weight") + 1
-    config[2] = get_max_seq_index(state_dict, "m_down3.{}.conv1_1.weight") + 1
-    config[3] = get_max_seq_index(state_dict, "m_body.{}.conv1_1.weight") + 1
-    config[4] = get_max_seq_index(state_dict, "m_up3.{}.conv1_1.weight", start=1)
-    config[5] = get_max_seq_index(state_dict, "m_up2.{}.conv1_1.weight", start=1)
-    config[6] = get_max_seq_index(state_dict, "m_up1.{}.conv1_1.weight", start=1)
+    config[0] = get_seq_len(state_dict, "m_down1") - 1
+    config[1] = get_seq_len(state_dict, "m_down2") - 1
+    config[2] = get_seq_len(state_dict, "m_down3") - 1
+    config[3] = get_seq_len(state_dict, "m_body")
+    config[4] = get_seq_len(state_dict, "m_up3") - 1
+    config[5] = get_seq_len(state_dict, "m_up2") - 1
+    config[6] = get_seq_len(state_dict, "m_up1") - 1
 
     model = SCUNet(
         in_nc=in_nc,

--- a/src/spandrel/architectures/__arch_helpers/state.py
+++ b/src/spandrel/architectures/__arch_helpers/state.py
@@ -4,28 +4,6 @@ import math
 from typing import Any
 
 
-def get_max_seq_index(state: dict, key_pattern: str, start: int = 0) -> int:
-    """
-    Returns the maximum number `i` such that `key_pattern.format(str(i))` is in `state`.
-
-    This is useful for detecting the number of elements in a sequence. Since this
-    function returns the highest index, the length of the sequence is simply
-    `get_max_seq_index(state, pattern) + 1`. This even correctly accounts for empty
-    sequences.
-
-    If no such key is in state, then `start - 1` is returned.
-
-    Example:
-        get_max_seq_index(state, "body.{}.weight") -> 5
-    """
-    i = start
-    while True:
-        key = key_pattern.format(str(i))
-        if key not in state:
-            return i - 1
-        i += 1
-
-
 def get_seq_len(state: dict[str, Any], seq_key: str) -> int:
     """
     Returns the length of a sequence in the state dict.


### PR DESCRIPTION
This migrates the last architecture to the much more easy-to-use `get_seq_len` and removes the now unused `get_max_seq_index`. 

I did this because `get_seq_len` has much better semantics than `get_max_seq_index`. E.g. `get_seq_len` can correctly handle sequences with elements that are not saved in the state dict, while `get_max_seq_index` cannot. `get_seq_len` also doesn't require a key pattern, which makes it independent of the items of the sequence.