### PR TITLE
Use neutral values in `SizeRequirements`

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -13,17 +13,23 @@ StateDict = Dict[str, Any]
 
 @dataclass
 class SizeRequirements:
-    minimum: int | None = None
+    minimum: int = 0
     """
     The minimum size of the input image in pixels.
+
+    Default/neutral value: `0`
     """
-    multiple_of: int | None = None
+    multiple_of: int = 1
     """
     The width and height of the image must be a multiple of this value.
+
+    Default/neutral value: `1`
     """
     square: bool = False
     """
     The image must be square.
+
+    Default/neutral value: `False`
     """
 
     @property
@@ -33,23 +39,20 @@ class SizeRequirements:
 
         If True, then `check` is guaranteed to always return True.
         """
-        return self.minimum is None and self.multiple_of is None and not self.square
+        return self.minimum == 0 and self.multiple_of == 1 and not self.square
 
     def check(self, width: int, height: int) -> bool:
         """
         Checks if the given width and height satisfy the size requirements.
         """
-        if self.minimum is not None:
-            if width < self.minimum or height < self.minimum:
-                return False
+        if width < self.minimum or height < self.minimum:
+            return False
 
-        if self.multiple_of is not None:
-            if width % self.multiple_of != 0 or height % self.multiple_of != 0:
-                return False
+        if width % self.multiple_of != 0 or height % self.multiple_of != 0:
+            return False
 
-        if self.square:
-            if width != height:
-                return False
+        if self.square and width != height:
+            return False
 
         return True
 

--- a/tests/__snapshots__/test_CodeFormer.ambr
+++ b/tests/__snapshots__/test_CodeFormer.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_Compact.ambr
+++ b/tests/__snapshots__/test_Compact.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -20,7 +20,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -20,7 +20,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -35,7 +35,7 @@
     input_channels=3,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -50,7 +50,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -65,7 +65,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -80,7 +80,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -95,7 +95,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -110,7 +110,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -125,7 +125,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -140,7 +140,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -155,7 +155,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -170,7 +170,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_FBCNN.ambr
+++ b/tests/__snapshots__/test_FBCNN.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -18,7 +18,7 @@
     input_channels=1,
     output_channels=1,
     scale=1,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_GFPGAN.ambr
+++ b/tests/__snapshots__/test_GFPGAN.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=512, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -18,7 +18,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=512, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -31,7 +31,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=512, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_HAT.ambr
+++ b/tests/__snapshots__/test_HAT.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -23,7 +23,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_LaMa.ambr
+++ b/tests/__snapshots__/test_LaMa.ambr
@@ -5,7 +5,7 @@
     input_channels=4,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_OmniSR.ambr
+++ b/tests/__snapshots__/test_OmniSR.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -21,7 +21,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_RestoreFormer.ambr
+++ b/tests/__snapshots__/test_RestoreFormer.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=8,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_SCUNet.ambr
+++ b/tests/__snapshots__/test_SCUNet.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -18,7 +18,7 @@
     input_channels=3,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -31,7 +31,7 @@
     input_channels=3,
     output_channels=3,
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -44,7 +44,7 @@
     input_channels=1,
     output_channels=1,
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_SwiftSRGAN.ambr
+++ b/tests/__snapshots__/test_SwiftSRGAN.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -20,7 +20,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=None, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_Swin2SR.ambr
+++ b/tests/__snapshots__/test_Swin2SR.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_SwinIR.ambr
+++ b/tests/__snapshots__/test_SwinIR.ambr
@@ -5,7 +5,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -23,7 +23,7 @@
     input_channels=3,
     output_channels=3,
     scale=4,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -41,7 +41,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -59,7 +59,7 @@
     input_channels=3,
     output_channels=3,
     scale=2,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=None, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([


### PR DESCRIPTION
I didn't like that `multiple_of=1` and `multiple_of=None` meant the same thing. Same for `minimum=0` and `minimum=None`.

So I removed `None` from `SizeRequirements` and used neutral values instead. This will hopefully make it easier to deal with `SizeRequirements`.

Note: This is a breaking change.