### PR TITLE
Add `ModelFile.load_model` to simplify tests

### DIFF
--- a/tests/test_CodeFormer.py
+++ b/tests/test_CodeFormer.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.CodeFormer import CodeFormer, load
 
 from .util import ModelFile, assert_loads_correctly, disallowed_props
@@ -24,6 +23,6 @@ def test_CodeFormer(snapshot):
     file = ModelFile.from_url(
         "https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, CodeFormer)

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.Compact import SRVGGNetCompact, load
 
 from .util import (
@@ -35,7 +34,7 @@ def test_Compact_realesr_general_x4v3(snapshot):
     file = ModelFile.from_url(
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesr-general-x4v3.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SRVGGNetCompact)
     assert_image_inference(
@@ -49,7 +48,7 @@ def test_Compact_community(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/2x-AniScale.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SRVGGNetCompact)
     assert_image_inference(

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.ESRGAN import RRDBNet
 
 from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
@@ -8,7 +7,7 @@ def test_ESRGAN_community(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Anti-Aliasing.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -22,7 +21,7 @@ def test_ESRGAN_community_2x(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/2x-BIGOLDIES.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -36,7 +35,7 @@ def test_ESRGAN_community_4x(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-NMKD-YandereNeo.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -50,7 +49,7 @@ def test_ESRGAN_community_8x(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/8x-ESRGAN.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -64,7 +63,7 @@ def test_BSRGAN(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/BSRGAN.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -78,7 +77,7 @@ def test_BSRGAN_2x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/BSRGANx2.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -92,7 +91,7 @@ def test_RealSR_DPED(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/RealSR_DPED.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -106,7 +105,7 @@ def test_RealSR_JPEG(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/RealSR_JPEG.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -120,7 +119,7 @@ def test_RealESRGAN_x4plus(snapshot):
     file = ModelFile.from_url(
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -134,7 +133,7 @@ def test_RealESRGAN_x2plus(snapshot):
     file = ModelFile.from_url(
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -148,7 +147,7 @@ def test_RealESRGAN_x4plus_anime_6B(snapshot):
     file = ModelFile.from_url(
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(
@@ -162,7 +161,7 @@ def test_RealESRNet_x4plus(snapshot):
     file = ModelFile.from_url(
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RRDBNet)
     assert_image_inference(

--- a/tests/test_FBCNN.py
+++ b/tests/test_FBCNN.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.FBCNN import FBCNN, load
 
 from .util import (
@@ -31,7 +30,7 @@ def test_FBCNN_color(snapshot):
     file = ModelFile.from_url(
         "https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_color.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, FBCNN)
     assert_image_inference(file, model, [TestImage.JPEG_15, TestImage.SR_8])
@@ -41,6 +40,6 @@ def test_FBCNN_gray(snapshot):
     file = ModelFile.from_url(
         "https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_gray.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, FBCNN)

--- a/tests/test_FeMaSR.py
+++ b/tests/test_FeMaSR.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.FeMaSR import FeMaSR, load
 from tests.test_GFPGAN import disallowed_props
 
@@ -39,7 +38,7 @@ def test_FeMaSR_1x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_HRP_model_g.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, FeMaSR)
     assert_image_inference(
@@ -53,7 +52,7 @@ def test_FeMaSR_2x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_SRX2_model_g.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, FeMaSR)
     assert_image_inference(
@@ -67,7 +66,7 @@ def test_FeMaSR_4x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_SRX4_model_g.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, FeMaSR)
     assert_image_inference(

--- a/tests/test_GFPGAN.py
+++ b/tests/test_GFPGAN.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.GFPGAN import GFPGANv1Clean
 
 from .util import ModelFile, disallowed_props
@@ -8,7 +7,7 @@ def test_GFPGAN_1_2(snapshot):
     file = ModelFile.from_url(
         "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.2.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GFPGANv1Clean)
 
@@ -17,7 +16,7 @@ def test_GFPGAN_1_3(snapshot):
     file = ModelFile.from_url(
         "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GFPGANv1Clean)
 
@@ -26,6 +25,6 @@ def test_GFPGAN_1_4(snapshot):
     file = ModelFile.from_url(
         "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/GFPGANv1.4.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GFPGANv1Clean)

--- a/tests/test_GRLIR.py
+++ b/tests/test_GRLIR.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.GRLIR import GRLIR, load
 
 from .util import (
@@ -117,7 +116,7 @@ def test_GRLIR_dn_grl_tiny_c1(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/dn_grl_tiny_c1.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     # this model is weird, so no inference test
@@ -127,7 +126,7 @@ def test_GRLIR_dn_grl_base_c1s25(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/dn_grl_base_c1s25.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     # we don't have grayscale images yet
@@ -137,7 +136,7 @@ def test_GRLIR_jpeg_grl_small_c1q30(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/jpeg_grl_small_c1q30.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     # we don't have grayscale images yet
@@ -147,7 +146,7 @@ def test_GRLIR_dn_grl_small_c3s15(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/dn_grl_small_c3s15.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(
@@ -161,7 +160,7 @@ def test_GRLIR_dn_grl_base_c3s50(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/dn_grl_base_c3s50.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(
@@ -175,7 +174,7 @@ def test_GRLIR_db_motion_grl_base_gopro(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/db_motion_grl_base_gopro.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(
@@ -189,7 +188,7 @@ def test_GRLIR_jpeg_grl_small_c3(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/jpeg_grl_small_c3.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     # this model is weird, so no inference test
@@ -199,7 +198,7 @@ def test_GRLIR_jpeg_grl_small_c3q20(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/jpeg_grl_small_c3q20.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(
@@ -213,7 +212,7 @@ def test_GRLIR_sr_grl_tiny_c3x3(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/sr_grl_tiny_c3x3.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(
@@ -227,7 +226,7 @@ def test_GRLIR_sr_grl_tiny_c3x4(snapshot):
     file = ModelFile.from_url(
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/sr_grl_tiny_c3x4.ckpt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, GRLIR)
     assert_image_inference(

--- a/tests/test_HAT.py
+++ b/tests/test_HAT.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.HAT import HAT, load
 
 from .util import (
@@ -53,7 +52,7 @@ def test_HAT_community1(snapshot):
     file = ModelFile.from_url(
         "https://github.com/Phhofm/models/raw/main/4xLexicaHAT/4xLexicaHAT.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, HAT)
     assert_image_inference(
@@ -67,7 +66,7 @@ def test_HAT_community2(snapshot):
     file = ModelFile.from_url(
         "https://github.com/Phhofm/models/raw/main/4xNomos8kSCHAT-S/4xNomos8kSCHAT-S.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, HAT)
     assert_image_inference(

--- a/tests/test_LaMa.py
+++ b/tests/test_LaMa.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.LaMa import LaMa, load
 
 from .util import ModelFile, assert_loads_correctly, disallowed_props
@@ -18,6 +17,6 @@ def test_LaMa(snapshot):
     file = ModelFile.from_url(
         "https://github.com/Sanster/models/releases/download/add_big_lama/big-lama.pt"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, LaMa)

--- a/tests/test_MAT.py
+++ b/tests/test_MAT.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.MAT import MAT
 
 from .util import ModelFile, disallowed_props
@@ -8,6 +7,6 @@ def test_MAT(snapshot):
     file = ModelFile.from_url(
         "https://github.com/Sanster/models/releases/download/add_mat/Places_512_FullData_G.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, MAT)

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.OmniSR import OmniSR, load
 
 from .util import (
@@ -37,7 +36,7 @@ def test_OmniSR_community1(snapshot):
     file = ModelFile.from_url(
         "https://github.com/Phhofm/models/raw/main/2xHFA2kAVCOmniSR/2xHFA2kAVCOmniSR.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, OmniSR)
     assert_image_inference(
@@ -51,7 +50,7 @@ def test_OmniSR_community2(snapshot):
     file = ModelFile.from_url(
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-ardo.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, OmniSR)
     assert_image_inference(

--- a/tests/test_RestoreFormer.py
+++ b/tests/test_RestoreFormer.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.RestoreFormer import RestoreFormer, load
 
 from .util import ModelFile, assert_loads_correctly, disallowed_props
@@ -33,6 +32,6 @@ def test_RestoreFormer(snapshot):
     file = ModelFile.from_url(
         "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/RestoreFormer.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, RestoreFormer)

--- a/tests/test_SCUNet.py
+++ b/tests/test_SCUNet.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.SCUNet import SCUNet, load
 
 from .util import ModelFile, assert_loads_correctly, disallowed_props
@@ -21,7 +20,7 @@ def test_SCUNet_color_GAN(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_gan.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SCUNet)
 
@@ -30,7 +29,7 @@ def test_SCUNet_color_RSNR(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_psnr.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SCUNet)
 
@@ -39,7 +38,7 @@ def test_SCUNet_color_25(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_25.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SCUNet)
 
@@ -48,6 +47,6 @@ def test_SCUNet_gray_25(snapshot):
     file = ModelFile.from_url(
         "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_gray_25.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SCUNet)

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.SwiftSRGAN import SwiftSRGAN, load
 
 from .util import (
@@ -27,7 +26,7 @@ def test_SwiftSRGAN_2x(snapshot):
     file = ModelFile("swift_srgan_2x.pth").download(
         "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_2x.pth.tar"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwiftSRGAN)
     assert_image_inference(
@@ -41,7 +40,7 @@ def test_SwiftSRGAN_4x(snapshot):
     file = ModelFile("swift_srgan_4x.pth").download(
         "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_4x.pth.tar"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwiftSRGAN)
     assert_image_inference(

--- a/tests/test_Swin2SR.py
+++ b/tests/test_Swin2SR.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.Swin2SR import Swin2SR
 
 from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
@@ -8,7 +7,7 @@ def test_Swin2SR_4x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/mv-lab/swin2sr/releases/download/v0.0.1/Swin2SR_ClassicalSR_X4_64.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, Swin2SR)
     assert_image_inference(

--- a/tests/test_SwinIR.py
+++ b/tests/test_SwinIR.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.SwinIR import SwinIR
 
 from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
@@ -8,7 +7,7 @@ def test_SwinIR_M_s64w8_2x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/001_classicalSR_DF2K_s64w8_SwinIR-M_x2.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
     assert_image_inference(
@@ -22,7 +21,7 @@ def test_SwinIR_M_s48w8_4x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/001_classicalSR_DIV2K_s48w8_SwinIR-M_x4.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
     assert_image_inference(
@@ -36,7 +35,7 @@ def test_SwinIR_S_2x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/002_lightweightSR_DIV2K_s64w8_SwinIR-S_x2.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
     assert_image_inference(
@@ -50,7 +49,7 @@ def test_SwinIR_L_4x(snapshot):
     file = ModelFile.from_url(
         "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/003_realSR_BSRGAN_DFOWMFC_s64w8_SwinIR-L_x4_PSNR.pth"
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, SwinIR)
     assert_image_inference(

--- a/tests/util.py
+++ b/tests/util.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 from syrupy.filters import props
 
-from spandrel.__helpers.model_descriptor import ModelBase, ModelDescriptor, StateDict
+from spandrel import ModelBase, ModelDescriptor, ModelLoader, StateDict
 
 MODEL_DIR = Path("./tests/models/")
 IMAGE_DIR = Path("./tests/images/")
@@ -45,6 +45,9 @@ class ModelFile:
         if not self.exists:
             download_model(url, name=self.name)
         return self
+
+    def load_model(self) -> ModelDescriptor:
+        return ModelLoader().load_from_file(self.path)
 
     @staticmethod
     def from_url(url: str):


### PR DESCRIPTION
I added a `load_model` method to `ModelFile` to simplify our tests and to get rid of the `from spandrel import ModelLoader` in all our test files.