### PR TITLE
Improved test `from_url` and `from_url_zip`

### DIFF
--- a/tests/test_DAT.py
+++ b/tests/test_DAT.py
@@ -1,4 +1,3 @@
-from spandrel import ModelLoader
 from spandrel.architectures.DAT import DAT, load
 
 from .util import (
@@ -49,7 +48,7 @@ def test_DAT_S_x4(snapshot):
         "https://drive.google.com/file/d/1iY30DyLYjar-2DjrJtAv2chCOlw4xiOj/view",
         name="DAT_S_x4.pth",
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, DAT)
     assert_image_inference(
@@ -64,7 +63,7 @@ def test_DAT_S_x3(snapshot):
         "https://drive.google.com/file/d/1Fmj7VFKznbak-atd6pEu59UTZxKTXYVi/view",
         name="DAT_S_x3.pth",
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, DAT)
     assert_image_inference(
@@ -79,7 +78,7 @@ def test_DAT_x4(snapshot):
         "https://drive.google.com/file/d/1pEhXmg--IWHaZOwHUFdh7TEJqt2qeuYg/view",
         name="DAT_x4.pth",
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, DAT)
     assert_image_inference(
@@ -94,7 +93,7 @@ def test_DAT_2_x4(snapshot):
         "https://drive.google.com/file/d/1sfB15jklXRjGiZZWgYXZAYc2Ut4TuKOz/view",
         name="DAT_2_x4.pth",
     )
-    model = ModelLoader().load_from_file(file.path)
+    model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
     assert isinstance(model.model, DAT)
     assert_image_inference(

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from spandrel.architectures.OmniSR import OmniSR, load
 
 from .util import (
@@ -37,7 +35,7 @@ def test_OmniSR_load():
 def test_OmniSR_official_x4(snapshot):
     file = ModelFile.from_url_zip(
         "https://drive.google.com/file/d/17rJXJHBYt4Su8cMDMh-NOWMBdE6ki5em/view",
-        rel_model_path=Path("OmniSR_X4_DF2K/checkpoints/epoch994_OmniSR.pth"),
+        rel_model_path="OmniSR_X4_DF2K/checkpoints/epoch994_OmniSR.pth",
         name="epoch994_OmniSR_x4.pth",
     )
     model = file.load_model()
@@ -48,7 +46,7 @@ def test_OmniSR_official_x4(snapshot):
 def test_OmniSR_official_x3(snapshot):
     file = ModelFile.from_url_zip(
         "https://drive.google.com/file/d/1Rwg6o-RGC-TEiyVSVT9FS1iHjx5n948h/view",
-        rel_model_path=Path("OmniSR_X3_DIV2K/checkpoints/epoch919_OmniSR.pth"),
+        rel_model_path="OmniSR_X3_DIV2K/checkpoints/epoch919_OmniSR.pth",
         name="epoch919_OmniSR_x3.pth",
     )
     model = file.load_model()
@@ -59,7 +57,7 @@ def test_OmniSR_official_x3(snapshot):
 def test_OmniSR_official_x2(snapshot):
     file = ModelFile.from_url_zip(
         "https://drive.google.com/file/d/18lSvJq9CGCwDomkas2gh8K6UOq8qRLIw/view",
-        rel_model_path=Path("OmniSR_X2_DIV2K/checkpoints/epoch896_OmniSR.pth"),
+        rel_model_path="OmniSR_X2_DIV2K/checkpoints/epoch896_OmniSR.pth",
         name="epoch896_OmniSR_x2.pth",
     )
     model = file.load_model()

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -23,8 +23,9 @@ def test_SwiftSRGAN_load():
 
 
 def test_SwiftSRGAN_2x(snapshot):
-    file = ModelFile("swift_srgan_2x.pth").download(
-        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_2x.pth.tar"
+    file = ModelFile.from_url(
+        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_2x.pth.tar",
+        name="swift_srgan_2x.pth",
     )
     model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)
@@ -37,8 +38,9 @@ def test_SwiftSRGAN_2x(snapshot):
 
 
 def test_SwiftSRGAN_4x(snapshot):
-    file = ModelFile("swift_srgan_4x.pth").download(
-        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_4x.pth.tar"
+    file = ModelFile.from_url(
+        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_4x.pth.tar",
+        name="swift_srgan_4x.pth",
     )
     model = file.load_model()
     assert model == snapshot(exclude=disallowed_props)


### PR DESCRIPTION
Changes:
- Use `file.load_model()` in DAT tests.
- Simplified implementation of both `from_url` and `from_url_zip`.
- `from_url_zip` will now error if a file already exists/the downloaded file isn't a zip. (fail fast)
- It will now only extract the requested file from the zip instead of extracting the entire zip into a temporary directory.