### PR TITLE
Add call API for models and new descriptor API

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -12,6 +12,7 @@
     "strictSetInference": true,
     "reportDuplicateImport": "warning",
     "reportImportCycles": "error",
+    "reportIncompatibleMethodOverride": "error",
     "reportIncompatibleVariableOverride": "error",
     "reportOverlappingOverload": "error",
     "reportPrivateImportUsage": "error",

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Literal, TypeVar, Union
 
 import torch
+from torch import Tensor
 
 T = TypeVar("T", bound=torch.nn.Module, covariant=True)
 
@@ -55,6 +56,17 @@ class SizeRequirements:
             return False
 
         return True
+
+
+Purpose = Literal["SR", "FaceSR", "Inpaint", "Restoration"]
+"""
+A short string describing the purpose of the model.
+
+- `SR`: Super resolution
+- `FaceSR`: Face super resolution
+- `Inpaint`: Image inpainting
+- `Restoration`: Image restoration (denoising, deblurring, JPEG, etc.)
+"""
 
 
 class ModelBase(ABC, Generic[T]):
@@ -123,31 +135,98 @@ class ModelBase(ABC, Generic[T]):
 
         self.model.load_state_dict(state_dict)  # type: ignore
 
+    @property
+    @abstractmethod
+    def purpose(self) -> Purpose:
+        """
+        The purpose of this model.
+        """
+        ...
+
     def to(self, device: torch.device):
         self.model.to(device)
         return self
 
+    def eval(self):
+        self.model.eval()
+        return self
 
-class SRModelDescriptor(ModelBase[T], Generic[T]):
-    pass
+    def train(self, mode: bool = True):
+        self.model.train(mode)
+        return self
 
 
-class FaceSRModelDescriptor(ModelBase[T], Generic[T]):
-    pass
+class ImageModelDescriptor(ModelBase[T], Generic[T]):
+    """
+    A model that takes an image as input and returns an image.
+    """
 
-
-class InpaintModelDescriptor(ModelBase[T], Generic[T]):
     def __init__(
         self,
         model: T,
         state_dict: StateDict,
         architecture: str,
+        purpose: Literal["SR", "FaceSR", "Restoration"],
+        tags: list[str],
+        supports_half: bool,
+        supports_bfloat16: bool,
+        scale: int,
+        input_channels: int,
+        output_channels: int,
+        size_requirements: SizeRequirements | None = None,
+        call_fn: Callable[[T, Tensor], Tensor] | None = None,
+    ):
+        assert (
+            purpose != "Restoration" or scale == 1
+        ), "Restoration models must have a scale of 1"
+
+        super().__init__(
+            model,
+            state_dict,
+            architecture,
+            tags,
+            supports_half=supports_half,
+            supports_bfloat16=supports_bfloat16,
+            scale=scale,
+            input_channels=input_channels,
+            output_channels=output_channels,
+            size_requirements=size_requirements,
+        )
+
+        self._purpose: Literal["SR", "FaceSR", "Restoration"] = purpose
+
+        self._call_fn = call_fn or (lambda model, image: model(image))
+
+    @property
+    def purpose(self) -> Literal["SR", "FaceSR", "Restoration"]:
+        return self._purpose
+
+    def __call__(self, image: Tensor) -> Tensor:
+        output = self._call_fn(self.model, image)
+        assert isinstance(
+            output, Tensor
+        ), f"Expected {type(self.model).__name__} model to returns a tensor, but got {type(output)}"
+        return output
+
+
+class MaskedImageModelDescriptor(ModelBase[T], Generic[T]):
+    """
+    A model that takes an image and a mask for that image as input and returns an image.
+    """
+
+    def __init__(
+        self,
+        model: T,
+        state_dict: StateDict,
+        architecture: str,
+        purpose: Literal["Inpaint"],
         tags: list[str],
         supports_half: bool,
         supports_bfloat16: bool,
         input_channels: int,
         output_channels: int,
         size_requirements: SizeRequirements | None = None,
+        call_fn: Callable[[T, Tensor, Tensor], Tensor] | None = None,
     ):
         super().__init__(
             model,
@@ -162,39 +241,25 @@ class InpaintModelDescriptor(ModelBase[T], Generic[T]):
             size_requirements=size_requirements,
         )
 
+        self._purpose: Literal["Inpaint"] = purpose
 
-class RestorationModelDescriptor(ModelBase[T], Generic[T]):
-    def __init__(
-        self,
-        model: T,
-        state_dict: StateDict,
-        architecture: str,
-        tags: list[str],
-        supports_half: bool,
-        supports_bfloat16: bool,
-        input_channels: int,
-        output_channels: int,
-        size_requirements: SizeRequirements | None = None,
-    ):
-        super().__init__(
-            model,
-            state_dict,
-            architecture,
-            tags,
-            supports_half=supports_half,
-            supports_bfloat16=supports_bfloat16,
-            scale=1,
-            input_channels=input_channels,
-            output_channels=output_channels,
-            size_requirements=size_requirements,
-        )
+        self._call_fn = call_fn or (lambda model, image, mask: model(image, mask))
+
+    @property
+    def purpose(self) -> Literal["Inpaint"]:
+        return self._purpose
+
+    def __call__(self, image: Tensor, mask: Tensor) -> Tensor:
+        output = self._call_fn(self.model, image, mask)
+        assert isinstance(
+            output, Tensor
+        ), f"Expected {type(self.model).__name__} model to returns a tensor, but got {type(output)}"
+        return output
 
 
 ModelDescriptor = Union[
-    SRModelDescriptor[torch.nn.Module],
-    FaceSRModelDescriptor[torch.nn.Module],
-    InpaintModelDescriptor[torch.nn.Module],
-    RestorationModelDescriptor[torch.nn.Module],
+    ImageModelDescriptor[torch.nn.Module],
+    MaskedImageModelDescriptor[torch.nn.Module],
 ]
 """
 A model descriptor is a loaded model with metadata. Metadata includes the

--- a/src/spandrel/__init__.py
+++ b/src/spandrel/__init__.py
@@ -4,13 +4,12 @@ from .__helpers.canonicalize import canonicalize_state_dict
 from .__helpers.loader import ModelLoader
 from .__helpers.main_registry import MAIN_REGISTRY
 from .__helpers.model_descriptor import (
-    FaceSRModelDescriptor,
-    InpaintModelDescriptor,
+    ImageModelDescriptor,
+    MaskedImageModelDescriptor,
     ModelBase,
     ModelDescriptor,
-    RestorationModelDescriptor,
+    Purpose,
     SizeRequirements,
-    SRModelDescriptor,
     StateDict,
 )
 from .__helpers.registry import ArchRegistry, ArchSupport, UnsupportedModelError
@@ -19,15 +18,14 @@ __all__ = [
     "ArchRegistry",
     "ArchSupport",
     "canonicalize_state_dict",
-    "FaceSRModelDescriptor",
-    "InpaintModelDescriptor",
+    "ImageModelDescriptor",
     "MAIN_REGISTRY",
+    "MaskedImageModelDescriptor",
     "ModelBase",
     "ModelDescriptor",
     "ModelLoader",
-    "RestorationModelDescriptor",
+    "Purpose",
     "SizeRequirements",
-    "SRModelDescriptor",
     "StateDict",
     "UnsupportedModelError",
 ]

--- a/src/spandrel/architectures/CodeFormer/__init__.py
+++ b/src/spandrel/architectures/CodeFormer/__init__.py
@@ -1,5 +1,5 @@
 from ...__helpers.model_descriptor import (
-    FaceSRModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -7,7 +7,7 @@ from ..__arch_helpers.state import get_seq_len
 from .arch.codeformer import CodeFormer
 
 
-def load(state_dict: StateDict) -> FaceSRModelDescriptor[CodeFormer]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[CodeFormer]:
     dim_embd = 512
     n_head = 8  # cannot be deduced from state dict
     n_layers = 9
@@ -41,10 +41,11 @@ def load(state_dict: StateDict) -> FaceSRModelDescriptor[CodeFormer]:
         fix_modules=fix_modules,
     )
 
-    return FaceSRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="CodeFormer",
+        purpose="FaceSR",
         tags=[],
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/Compact/__init__.py
+++ b/src/spandrel/architectures/Compact/__init__.py
@@ -1,9 +1,9 @@
-from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
 from ..__arch_helpers.state import get_scale_and_output_channels, get_seq_len
 from .arch.SRVGG import SRVGGNetCompact
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[SRVGGNetCompact]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[SRVGGNetCompact]:
     state = state_dict
 
     highest_num = get_seq_len(state, "body") - 1
@@ -25,10 +25,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[SRVGGNetCompact]:
 
     tags = [f"{num_feat}nf", f"{num_conv}nc"]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state,
         architecture="RealESRGAN Compact",
+        purpose="Restoration" if scale == 1 else "SR",
         tags=tags,
         supports_half=True,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/DAT/__init__.py
+++ b/src/spandrel/architectures/DAT/__init__.py
@@ -1,11 +1,15 @@
 import math
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import get_seq_len
 from .arch.DAT import DAT
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[DAT]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[DAT]:
     # defaults
     img_size = 64  # cannot be deduced from state dict in general
     in_chans = 3
@@ -102,10 +106,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[DAT]:
         f"{resi_connection}",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="DAT",
+        purpose="Restoration" if upscale == 1 else "SR",
         tags=tags,
         supports_half=False,  # Too much weirdness to support this at the moment
         supports_bfloat16=True,

--- a/src/spandrel/architectures/ESRGAN/__init__.py
+++ b/src/spandrel/architectures/ESRGAN/__init__.py
@@ -3,7 +3,7 @@ import math
 import re
 from collections import OrderedDict
 
-from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
 from .arch.RRDB import RRDBNet
 
 
@@ -97,7 +97,7 @@ def _get_num_blocks(state: StateDict, state_map: dict) -> int:
     return max(*nbs) + 1
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[RRDBNet]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[RRDBNet]:
     state = state_dict
     model_arch = "ESRGAN"
 
@@ -165,10 +165,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[RRDBNet]:
         in_nc //= shuffle_factor**2
         scale //= shuffle_factor
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state,
         architecture=model_arch,
+        purpose="Restoration" if scale == 1 else "SR",
         tags=tags,
         supports_half=True,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/FBCNN/__init__.py
+++ b/src/spandrel/architectures/FBCNN/__init__.py
@@ -1,12 +1,12 @@
 from ...__helpers.model_descriptor import (
-    RestorationModelDescriptor,
+    ImageModelDescriptor,
     StateDict,
 )
 from ..__arch_helpers.state import get_seq_len
 from .arch.FBCNN import FBCNN
 
 
-def load(state_dict: StateDict) -> RestorationModelDescriptor[FBCNN]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[FBCNN]:
     in_nc = 3
     out_nc = 3
     nc = [64, 128, 256, 512]
@@ -51,13 +51,16 @@ def load(state_dict: StateDict) -> RestorationModelDescriptor[FBCNN]:
         upsample_mode=upsample_mode,
     )
 
-    return RestorationModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="FBCNN",
+        purpose="Restoration",
         tags=[],
         supports_half=True,  # TODO
         supports_bfloat16=True,  # TODO
+        scale=1,
         input_channels=in_nc,
         output_channels=out_nc,
+        call_fn=lambda model, image: model(image)[0],
     )

--- a/src/spandrel/architectures/FBCNN/arch/FBCNN.py
+++ b/src/spandrel/architectures/FBCNN/arch/FBCNN.py
@@ -585,5 +585,4 @@ class FBCNN(nn.Module):
         x = self.m_tail(x)
         x = x[..., :h, :w]
 
-        # return x, qf
-        return x
+        return x, qf

--- a/src/spandrel/architectures/FeMaSR/__init__.py
+++ b/src/spandrel/architectures/FeMaSR/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import get_first_seq_index, get_seq_len
 from .arch.femasr import FeMaSRNet as FeMaSR
 
@@ -24,7 +28,7 @@ def _clean_state_dict(state_dict: StateDict):
             del state_dict[k]
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[FeMaSR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[FeMaSR]:
     _clean_state_dict(state_dict)
 
     # in_channel = 3
@@ -107,10 +111,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[FeMaSR]:
 
     multiple_of = {2: 32, 4: 16}.get(scale_factor, 1)
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="FeMaSR",
+        purpose="Restoration" if scale_factor == 1 else "SR",
         tags=[],
         supports_half=True,  # TODO
         supports_bfloat16=True,  # TODO
@@ -118,4 +123,5 @@ def load(state_dict: StateDict) -> SRModelDescriptor[FeMaSR]:
         input_channels=in_channel,
         output_channels=in_channel,
         size_requirements=SizeRequirements(multiple_of=multiple_of),
+        call_fn=lambda model, image: model(image)[0],
     )

--- a/src/spandrel/architectures/FeMaSR/arch/femasr.py
+++ b/src/spandrel/architectures/FeMaSR/arch/femasr.py
@@ -536,5 +536,4 @@ class FeMaSRNet(nn.Module):
             # in HQ stage, or LQ test stage, no GT indices needed.
             dec, codebook_loss, semantic_loss, indices = self.encode_and_decode(input)  # type: ignore
 
-        # return dec, codebook_loss, semantic_loss, indices
-        return dec
+        return dec, codebook_loss, semantic_loss, indices

--- a/src/spandrel/architectures/GFPGAN/__init__.py
+++ b/src/spandrel/architectures/GFPGAN/__init__.py
@@ -1,12 +1,12 @@
 from ...__helpers.model_descriptor import (
-    FaceSRModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
 from .arch.gfpganv1_clean_arch import GFPGANv1Clean
 
 
-def load(state_dict: StateDict) -> FaceSRModelDescriptor[GFPGANv1Clean]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[GFPGANv1Clean]:
     out_size = 512
     num_style_feat = 512
     channel_multiplier = 2
@@ -31,10 +31,11 @@ def load(state_dict: StateDict) -> FaceSRModelDescriptor[GFPGANv1Clean]:
         sft_half=sft_half,
     )
 
-    return FaceSRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="GFPGAN",
+        purpose="FaceSR",
         tags=[],
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/GRLIR/__init__.py
+++ b/src/spandrel/architectures/GRLIR/__init__.py
@@ -6,7 +6,7 @@ from typing import Literal
 import torch
 
 from ...__helpers.canonicalize import remove_common_prefix
-from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
 from ..__arch_helpers.state import get_scale_and_output_channels, get_seq_len
 from .arch.grl import GRL as GRLIR
 
@@ -132,7 +132,7 @@ def _inv_div_add(a: int, d: int) -> int:
     return round(a / (1 + 1 / d))
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[GRLIR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[GRLIR]:
     state_dict = _clean_up_checkpoint(state_dict)
 
     img_size: int = 64
@@ -302,10 +302,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[GRLIR]:
     if len(depths) < 6:
         size_tag = "small" if embed_dim >= 96 else "tiny"
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="GRLIR",
+        purpose="Restoration" if upscale == 1 else "SR",
         tags=[
             size_tag,
             f"{embed_dim}dim",

--- a/src/spandrel/architectures/GRLIR/arch/swin_v1_block.py
+++ b/src/spandrel/architectures/GRLIR/arch/swin_v1_block.py
@@ -182,7 +182,7 @@ class WindowAttentionWrapperV1(WindowAttentionV1):
             attn_mask = None
         self.register_buffer("attn_mask", attn_mask)
 
-    def forward(self, x, x_size):
+    def forward(self, x, x_size):  # type: ignore
         H, W = x_size
         B, _L, C = x.shape
         x = x.view(B, H, W, C)
@@ -460,7 +460,7 @@ class Linear(nn.Linear):
     def __init__(self, in_features, out_features, bias=True):
         super().__init__(in_features, out_features, bias)
 
-    def forward(self, x):
+    def forward(self, x):  # type: ignore
         _B, _C, H, W = x.shape
         x = bchw_to_blc(x)
         x = super().forward(x)

--- a/src/spandrel/architectures/HAT/__init__.py
+++ b/src/spandrel/architectures/HAT/__init__.py
@@ -1,6 +1,10 @@
 import math
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import get_seq_len
 from .arch.HAT import HAT
 
@@ -47,7 +51,7 @@ def _inv_int_div(a: int, c: int) -> float:
     raise ValueError(f"Could not find a number b such that a // b == c. a={a}, c={c}")
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[HAT]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[HAT]:
     img_size = 64
     patch_size = 1
     in_chans = 3
@@ -189,10 +193,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[HAT]:
         f"{resi_connection}",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="HAT",
+        purpose="Restoration" if upscale == 1 else "SR",
         tags=tags,
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/KBNet/__init__.py
+++ b/src/spandrel/architectures/KBNet/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ...__helpers.model_descriptor import (
-    RestorationModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -12,7 +12,7 @@ from .arch.kbnet_s import KBNet_s
 # KBCNN is essentially 2 similar but different architectures: KBNet_l and KBNet_s.
 
 
-def load_l(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_l]:
+def load_l(state_dict: StateDict) -> ImageModelDescriptor[KBNet_l]:
     in_nc = 3
     out_nc = 3
     dim = 48
@@ -56,20 +56,22 @@ def load_l(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_l]:
         bias=bias,
     )
 
-    return RestorationModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="KBCNN",
+        purpose="Restoration",
         tags=["L"],
         supports_half=False,
         supports_bfloat16=True,
+        scale=1,
         input_channels=in_nc,
         output_channels=out_nc,
         size_requirements=SizeRequirements(multiple_of=16),
     )
 
 
-def load_s(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_s]:
+def load_s(state_dict: StateDict) -> ImageModelDescriptor[KBNet_s]:
     img_channel = 3
     width = 64
     middle_blk_num = 12
@@ -112,13 +114,15 @@ def load_s(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_s]:
         ffn_scale=ffn_scale,
     )
 
-    return RestorationModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="KBCNN",
+        purpose="Restoration",
         tags=["S"],
         supports_half=False,
         supports_bfloat16=True,
+        scale=1,
         input_channels=img_channel,
         output_channels=img_channel,
     )
@@ -126,7 +130,7 @@ def load_s(state_dict: StateDict) -> RestorationModelDescriptor[KBNet_s]:
 
 def load(
     state_dict: StateDict
-) -> RestorationModelDescriptor[KBNet_l] | RestorationModelDescriptor[KBNet_s]:
+) -> ImageModelDescriptor[KBNet_l] | ImageModelDescriptor[KBNet_s]:
     if "patch_embed.proj.weight" in state_dict:
         return load_l(state_dict)
     else:

--- a/src/spandrel/architectures/LaMa/__init__.py
+++ b/src/spandrel/architectures/LaMa/__init__.py
@@ -1,5 +1,5 @@
 from ...__helpers.model_descriptor import (
-    InpaintModelDescriptor,
+    MaskedImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -7,7 +7,7 @@ from ..__arch_helpers.state import get_seq_len
 from .arch.LaMa import LaMa
 
 
-def load(state_dict: StateDict) -> InpaintModelDescriptor[LaMa]:
+def load(state_dict: StateDict) -> MaskedImageModelDescriptor[LaMa]:
     state_dict = {
         k.replace("generator.model", "model.model"): v for k, v in state_dict.items()
     }
@@ -25,10 +25,11 @@ def load(state_dict: StateDict) -> InpaintModelDescriptor[LaMa]:
         out_nc=out_nc,
     )
 
-    return InpaintModelDescriptor(
+    return MaskedImageModelDescriptor(
         model,
         state_dict,
         architecture="LaMa",
+        purpose="Inpaint",
         tags=[],
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/MAT/__init__.py
+++ b/src/spandrel/architectures/MAT/__init__.py
@@ -1,12 +1,12 @@
 from ...__helpers.model_descriptor import (
-    InpaintModelDescriptor,
+    MaskedImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
 from .arch.MAT import MAT
 
 
-def load(state_dict: StateDict) -> InpaintModelDescriptor[MAT]:
+def load(state_dict: StateDict) -> MaskedImageModelDescriptor[MAT]:
     in_nc = 3
     out_nc = 3
 
@@ -17,10 +17,11 @@ def load(state_dict: StateDict) -> InpaintModelDescriptor[MAT]:
 
     model = MAT()
 
-    return InpaintModelDescriptor(
+    return MaskedImageModelDescriptor(
         model,
         state,
         architecture="MAT",
+        purpose="Inpaint",
         tags=[],
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/OmniSR/__init__.py
+++ b/src/spandrel/architectures/OmniSR/__init__.py
@@ -1,6 +1,10 @@
 import math
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import (
     get_scale_and_output_channels,
     get_seq_len,
@@ -8,7 +12,7 @@ from ..__arch_helpers.state import (
 from .arch.OmniSR import OmniSR
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[OmniSR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[OmniSR]:
     # Remove junk from the state dict
     state_dict_keys = set(state_dict.keys())
     for key in state_dict_keys:
@@ -64,10 +68,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[OmniSR]:
         f"{res_num}nr",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="OmniSR",
+        purpose="Restoration" if up_scale == 1 else "SR",
         tags=tags,
         supports_half=True,  # TODO: Test this
         supports_bfloat16=True,

--- a/src/spandrel/architectures/RestoreFormer/__init__.py
+++ b/src/spandrel/architectures/RestoreFormer/__init__.py
@@ -1,5 +1,5 @@
 from ...__helpers.model_descriptor import (
-    FaceSRModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -7,7 +7,7 @@ from ..__arch_helpers.state import get_seq_len
 from .arch.restoreformer_arch import RestoreFormer
 
 
-def load(state_dict: StateDict) -> FaceSRModelDescriptor[RestoreFormer]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[RestoreFormer]:
     n_embed = 1024
     embed_dim = 256
     ch = 64
@@ -61,10 +61,11 @@ def load(state_dict: StateDict) -> FaceSRModelDescriptor[RestoreFormer]:
         head_size=head_size,
     )
 
-    return FaceSRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="RestoreFormer",
+        purpose="FaceSR",
         tags=[],
         supports_half=False,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/SCUNet/__init__.py
+++ b/src/spandrel/architectures/SCUNet/__init__.py
@@ -1,5 +1,5 @@
 from ...__helpers.model_descriptor import (
-    RestorationModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -7,7 +7,7 @@ from ..__arch_helpers.state import get_seq_len
 from .arch.SCUNet import SCUNet
 
 
-def load(state_dict: StateDict) -> RestorationModelDescriptor[SCUNet]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[SCUNet]:
     in_nc = 3
     config = [4, 4, 4, 4, 4, 4, 4]
     dim = 64
@@ -33,13 +33,15 @@ def load(state_dict: StateDict) -> RestorationModelDescriptor[SCUNet]:
         input_resolution=input_resolution,
     )
 
-    return RestorationModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="SCUNet",
+        purpose="Restoration",
         tags=[],
         supports_half=True,
         supports_bfloat16=True,
+        scale=1,
         input_channels=in_nc,
         output_channels=in_nc,
         size_requirements=SizeRequirements(minimum=16),

--- a/src/spandrel/architectures/SPSR/__init__.py
+++ b/src/spandrel/architectures/SPSR/__init__.py
@@ -1,4 +1,4 @@
-from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
 from .arch.SPSR import SPSRNet as SPSR
 
 
@@ -23,7 +23,7 @@ def get_num_blocks(state: StateDict) -> int:
     return nb
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[SPSR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[SPSR]:
     state = state_dict
 
     num_blocks = get_num_blocks(state)
@@ -46,10 +46,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[SPSR]:
         f"{num_blocks}nb",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state,
         architecture="SPSR",
+        purpose="Restoration" if scale == 1 else "SR",
         tags=tags,
         supports_half=True,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/SRFormer/__init__.py
+++ b/src/spandrel/architectures/SRFormer/__init__.py
@@ -3,11 +3,15 @@ import re
 
 from torch import nn
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from .arch.SRFormer import SRFormer
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[SRFormer]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[SRFormer]:
     # Default
     img_size = 64
     patch_size = 1
@@ -184,10 +188,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[SRFormer]:
         f"{resi_connection}",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state,
         architecture="SRFormer",
+        purpose="Restoration" if scale == 1 else "SR",
         tags=tags,
         supports_half=False,  # Too much weirdness to support this at the moment
         supports_bfloat16=True,

--- a/src/spandrel/architectures/SwiftSRGAN/__init__.py
+++ b/src/spandrel/architectures/SwiftSRGAN/__init__.py
@@ -1,9 +1,9 @@
-from ...__helpers.model_descriptor import SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
 from ..__arch_helpers.state import get_seq_len
 from .arch.SwiftSRGAN import Generator as SwiftSRGAN
 
 
-def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
+def load(state: StateDict) -> ImageModelDescriptor[SwiftSRGAN]:
     in_channels: int = 3
     num_channels: int = 64
     num_blocks: int = 16
@@ -25,10 +25,11 @@ def load(state: StateDict) -> SRModelDescriptor[SwiftSRGAN]:
         f"{num_blocks}nb",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state,
         architecture="Swift-SRGAN",
+        purpose="Restoration" if upscale_factor == 1 else "SR",
         tags=tags,
         supports_half=True,
         supports_bfloat16=True,

--- a/src/spandrel/architectures/Swin2SR/__init__.py
+++ b/src/spandrel/architectures/Swin2SR/__init__.py
@@ -1,11 +1,15 @@
 import math
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import get_seq_len
 from .arch.Swin2SR import Swin2SR
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[Swin2SR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[Swin2SR]:
     # Defaults
     img_size = 64
     patch_size = 1
@@ -149,10 +153,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[Swin2SR]:
         f"{resi_connection}",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="Swin2SR",
+        purpose="Restoration" if upscale == 1 else "SR",
         tags=tags,
         supports_half=False,  # Too much weirdness to support this at the moment
         supports_bfloat16=True,

--- a/src/spandrel/architectures/SwinIR/__init__.py
+++ b/src/spandrel/architectures/SwinIR/__init__.py
@@ -3,11 +3,15 @@ import re
 
 from torch import nn
 
-from ...__helpers.model_descriptor import SizeRequirements, SRModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from .arch.SwinIR import SwinIR
 
 
-def load(state_dict: StateDict) -> SRModelDescriptor[SwinIR]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[SwinIR]:
     # Defaults
     img_size = 64
     patch_size = 1
@@ -196,10 +200,11 @@ def load(state_dict: StateDict) -> SRModelDescriptor[SwinIR]:
         f"{resi_connection}",
     ]
 
-    return SRModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="SwinIR",
+        purpose="Restoration" if upscale == 1 else "SR",
         tags=tags,
         supports_half=False,  # Too much weirdness to support this at the moment
         supports_bfloat16=True,

--- a/src/spandrel/architectures/Uformer/__init__.py
+++ b/src/spandrel/architectures/Uformer/__init__.py
@@ -1,7 +1,7 @@
 import math
 
 from ...__helpers.model_descriptor import (
-    RestorationModelDescriptor,
+    ImageModelDescriptor,
     SizeRequirements,
     StateDict,
 )
@@ -9,7 +9,7 @@ from ..__arch_helpers.state import get_seq_len
 from .arch.Uformer import Uformer
 
 
-def load(state_dict: StateDict) -> RestorationModelDescriptor[Uformer]:
+def load(state_dict: StateDict) -> ImageModelDescriptor[Uformer]:
     img_size = 256  # cannot be deduced from state_dict
     in_chans = 3
     dd_in = 3
@@ -107,13 +107,15 @@ def load(state_dict: StateDict) -> RestorationModelDescriptor[Uformer]:
         cross_modulator=cross_modulator,
     )
 
-    return RestorationModelDescriptor(
+    return ImageModelDescriptor(
         model,
         state_dict,
         architecture="Uformer",
+        purpose="Restoration",
         tags=[],
         supports_half=False,  # Too much weirdness to support this at the moment
         supports_bfloat16=True,
+        scale=1,
         input_channels=dd_in,
         output_channels=dd_in,
         size_requirements=SizeRequirements(multiple_of=128, square=True),

--- a/tests/__snapshots__/test_CodeFormer.ambr
+++ b/tests/__snapshots__/test_CodeFormer.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_CodeFormer
-  FaceSRModelDescriptor(
+  ImageModelDescriptor(
     architecture='CodeFormer',
     input_channels=3,
     output_channels=3,
+    purpose='FaceSR',
     scale=8,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_Compact.ambr
+++ b/tests/__snapshots__/test_Compact.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_Compact_community
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='RealESRGAN Compact',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -15,10 +16,11 @@
   )
 # ---
 # name: test_Compact_realesr_general_x4v3
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='RealESRGAN Compact',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_DAT.ambr
+++ b/tests/__snapshots__/test_DAT.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_DAT_2_x4
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -19,10 +20,11 @@
   )
 # ---
 # name: test_DAT_S_x3
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=3,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -38,10 +40,11 @@
   )
 # ---
 # name: test_DAT_S_x4
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -57,10 +60,11 @@
   )
 # ---
 # name: test_DAT_tags
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -76,10 +80,11 @@
   )
 # ---
 # name: test_DAT_tags.1
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -95,10 +100,11 @@
   )
 # ---
 # name: test_DAT_tags.2
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -114,10 +120,11 @@
   )
 # ---
 # name: test_DAT_tags.3
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -133,10 +140,11 @@
   )
 # ---
 # name: test_DAT_x4
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='DAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_BSRGAN
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -15,10 +16,11 @@
   )
 # ---
 # name: test_BSRGAN_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -30,10 +32,11 @@
   )
 # ---
 # name: test_ESRGAN_community
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -45,10 +48,11 @@
   )
 # ---
 # name: test_ESRGAN_community_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -60,10 +64,11 @@
   )
 # ---
 # name: test_ESRGAN_community_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -75,10 +80,11 @@
   )
 # ---
 # name: test_ESRGAN_community_8x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=8,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -90,10 +96,11 @@
   )
 # ---
 # name: test_RealESRGAN_x2plus
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -105,10 +112,11 @@
   )
 # ---
 # name: test_RealESRGAN_x4plus
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -120,10 +128,11 @@
   )
 # ---
 # name: test_RealESRGAN_x4plus_anime_6B
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -135,10 +144,11 @@
   )
 # ---
 # name: test_RealESRNet_x4plus
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -150,10 +160,11 @@
   )
 # ---
 # name: test_RealSR_DPED
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -165,10 +176,11 @@
   )
 # ---
 # name: test_RealSR_JPEG
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='ESRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_FBCNN.ambr
+++ b/tests/__snapshots__/test_FBCNN.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_FBCNN_color
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='FBCNN',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -13,10 +14,11 @@
   )
 # ---
 # name: test_FBCNN_gray
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='FBCNN',
     input_channels=1,
     output_channels=1,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_FeMaSR.ambr
+++ b/tests/__snapshots__/test_FeMaSR.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_FeMaSR_1x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='FeMaSR',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -13,10 +14,11 @@
   )
 # ---
 # name: test_FeMaSR_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='FeMaSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=32, square=False),
     supports_bfloat16=True,
@@ -26,10 +28,11 @@
   )
 # ---
 # name: test_FeMaSR_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='FeMaSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=16, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_GFPGAN.ambr
+++ b/tests/__snapshots__/test_GFPGAN.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_GFPGAN_1_2
-  FaceSRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GFPGAN',
     input_channels=3,
     output_channels=3,
+    purpose='FaceSR',
     scale=8,
     size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -13,10 +14,11 @@
   )
 # ---
 # name: test_GFPGAN_1_3
-  FaceSRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GFPGAN',
     input_channels=3,
     output_channels=3,
+    purpose='FaceSR',
     scale=8,
     size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -26,10 +28,11 @@
   )
 # ---
 # name: test_GFPGAN_1_4
-  FaceSRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GFPGAN',
     input_channels=3,
     output_channels=3,
+    purpose='FaceSR',
     scale=8,
     size_requirements=SizeRequirements(minimum=512, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_GRLIR.ambr
+++ b/tests/__snapshots__/test_GRLIR.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_GRLIR_bsr_grl_base
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GRLIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -17,10 +18,11 @@
   )
 # ---
 # name: test_GRLIR_sr_grl_tiny_c3x3
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GRLIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=3,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -34,10 +36,11 @@
   )
 # ---
 # name: test_GRLIR_sr_grl_tiny_c3x4
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='GRLIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_HAT.ambr
+++ b/tests/__snapshots__/test_HAT.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_HAT_3x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=3,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -18,10 +19,11 @@
   )
 # ---
 # name: test_HAT_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -36,10 +38,11 @@
   )
 # ---
 # name: test_HAT_L_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -54,10 +57,11 @@
   )
 # ---
 # name: test_HAT_S_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -72,10 +76,11 @@
   )
 # ---
 # name: test_HAT_S_3x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=3,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -90,10 +95,11 @@
   )
 # ---
 # name: test_HAT_S_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -108,10 +114,11 @@
   )
 # ---
 # name: test_HAT_community1
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -126,10 +133,11 @@
   )
 # ---
 # name: test_HAT_community2
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='HAT',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_LaMa.ambr
+++ b/tests/__snapshots__/test_LaMa.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_LaMa
-  InpaintModelDescriptor(
+  MaskedImageModelDescriptor(
     architecture='LaMa',
     input_channels=4,
     output_channels=3,
+    purpose='Inpaint',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_MAT.ambr
+++ b/tests/__snapshots__/test_MAT.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_MAT
-  InpaintModelDescriptor(
+  MaskedImageModelDescriptor(
     architecture='MAT',
     input_channels=3,
     output_channels=3,
+    purpose='Inpaint',
     scale=1,
     size_requirements=SizeRequirements(minimum=512, multiple_of=512, square=True),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_OmniSR.ambr
+++ b/tests/__snapshots__/test_OmniSR.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_OmniSR_community1
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='OmniSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -16,10 +17,11 @@
   )
 # ---
 # name: test_OmniSR_community2
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='OmniSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -32,10 +34,11 @@
   )
 # ---
 # name: test_OmniSR_official_x2
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='OmniSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -48,10 +51,11 @@
   )
 # ---
 # name: test_OmniSR_official_x3
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='OmniSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=3,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -64,10 +68,11 @@
   )
 # ---
 # name: test_OmniSR_official_x4
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='OmniSR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_RestoreFormer.ambr
+++ b/tests/__snapshots__/test_RestoreFormer.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_RestoreFormer
-  FaceSRModelDescriptor(
+  ImageModelDescriptor(
     architecture='RestoreFormer',
     input_channels=3,
     output_channels=3,
+    purpose='FaceSR',
     scale=8,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_SCUNet.ambr
+++ b/tests/__snapshots__/test_SCUNet.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_SCUNet_color_25
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='SCUNet',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -13,10 +14,11 @@
   )
 # ---
 # name: test_SCUNet_color_GAN
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='SCUNet',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -26,10 +28,11 @@
   )
 # ---
 # name: test_SCUNet_color_RSNR
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='SCUNet',
     input_channels=3,
     output_channels=3,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -39,10 +42,11 @@
   )
 # ---
 # name: test_SCUNet_gray_25
-  RestorationModelDescriptor(
+  ImageModelDescriptor(
     architecture='SCUNet',
     input_channels=1,
     output_channels=1,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_SwiftSRGAN.ambr
+++ b/tests/__snapshots__/test_SwiftSRGAN.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_SwiftSRGAN_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swift-SRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -15,10 +16,11 @@
   )
 # ---
 # name: test_SwiftSRGAN_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swift-SRGAN',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_Swin2SR.ambr
+++ b/tests/__snapshots__/test_Swin2SR.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_Swin2SR_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swin2SR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -17,10 +18,11 @@
   )
 # ---
 # name: test_Swin2SR_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swin2SR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -34,10 +36,11 @@
   )
 # ---
 # name: test_Swin2SR_compressed
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swin2SR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -51,10 +54,11 @@
   )
 # ---
 # name: test_Swin2SR_jpeg
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swin2SR',
     input_channels=1,
     output_channels=1,
+    purpose='Restoration',
     scale=1,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -68,10 +72,11 @@
   )
 # ---
 # name: test_Swin2SR_lightweight_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='Swin2SR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/__snapshots__/test_SwinIR.ambr
+++ b/tests/__snapshots__/test_SwinIR.ambr
@@ -1,9 +1,10 @@
 # serializer version: 1
 # name: test_SwinIR_L_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='SwinIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -18,10 +19,11 @@
   )
 # ---
 # name: test_SwinIR_M_s48w8_4x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='SwinIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=4,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -36,10 +38,11 @@
   )
 # ---
 # name: test_SwinIR_M_s64w8_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='SwinIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,
@@ -54,10 +57,11 @@
   )
 # ---
 # name: test_SwinIR_S_2x
-  SRModelDescriptor(
+  ImageModelDescriptor(
     architecture='SwinIR',
     input_channels=3,
     output_channels=3,
+    purpose='SR',
     scale=2,
     size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
     supports_bfloat16=True,

--- a/tests/util.py
+++ b/tests/util.py
@@ -18,7 +18,13 @@ import numpy as np
 import torch
 from syrupy.filters import props
 
-from spandrel import ModelBase, ModelDescriptor, ModelLoader, StateDict
+from spandrel import (
+    ImageModelDescriptor,
+    ModelBase,
+    ModelDescriptor,
+    ModelLoader,
+    StateDict,
+)
 
 MODEL_DIR = Path("./tests/models/")
 IMAGE_DIR = Path("./tests/images/")
@@ -140,14 +146,14 @@ def tensor_to_image(tensor: torch.Tensor) -> np.ndarray:
 
 
 def image_inference_tensor(
-    model: torch.nn.Module, tensor: torch.Tensor
+    model: ImageModelDescriptor, tensor: torch.Tensor
 ) -> torch.Tensor:
     model.eval()
     with torch.no_grad():
         return model(tensor)
 
 
-def image_inference(model: torch.nn.Module, image: np.ndarray) -> np.ndarray:
+def image_inference(model: ImageModelDescriptor, image: np.ndarray) -> np.ndarray:
     return tensor_to_image(image_inference_tensor(model, image_to_tensor(image)))
 
 
@@ -170,6 +176,8 @@ def assert_image_inference(
     model: ModelDescriptor,
     test_images: list[TestImage],
 ):
+    assert isinstance(model, ImageModelDescriptor)
+
     test_images.sort(key=lambda image: image.value)
 
     update_mode = "--snapshot-update" in sys.argv
@@ -185,7 +193,7 @@ def assert_image_inference(
         ), f"Expected the input image '{test_image.value}' to have {model.input_channels} channels, but it had {image_c} channels."
 
         try:
-            output = image_inference(model.model, image)
+            output = image_inference(model, image)
         except Exception as e:
             raise AssertionError(f"Failed on {test_image.value}") from e
         output_h, output_w, output_c = get_h_w_c(output)


### PR DESCRIPTION
This removes the `<purpose>ModelDescriptor` classes and replaces them with `ImageModelDescriptor` and `MaskedImageModelDescriptor`. These 2 classes also define the call API of models. 

Models can optionally specify how they want to be called. This allowed me to remove the modification to the `forward` methods of `FBCNN` and `FeMaSR`.

Since this changes the API of spandrel, this is obviously a breaking change.

Notes:
- I also added `eval` and `train` methods `ModelBase` to make the API of model descriptors more similar to that of models.
- `purpose` is an abstract property in `ModelBase` because of variance. Fields are *always* mutable in python, so they are invariant (derived classes cannot change the type of the field). Since I wanted sub classes to narrow down the type of `purpose`, it had to be covariant. Hence, I had to make it an abstract property. 
  I even enabled the `reportIncompatibleMethodOverride` pyright rule to make sure I get the variance right.