### PR TITLE
Update cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: tests/models
-                  key: models
+                  key: update-2023-11-29
             - run: pytest tests
 


### PR DESCRIPTION
`actions/cache` only updates the cache when the cache key changes. So the cache hasn't been updated ever since it was added. This PR changes the cache key to update the cache.