### PR TITLE
Add information about tiling

### DIFF
--- a/src/spandrel/architectures/DDColor/__init__.py
+++ b/src/spandrel/architectures/DDColor/__init__.py
@@ -6,6 +6,7 @@ from torch import Tensor
 
 from ...__helpers.model_descriptor import (
     ImageModelDescriptor,
+    ModelTiling,
     StateDict,
 )
 from ..__arch_helpers.color import lab_to_rgb, linear_rgb_to_lab, rgb_to_linear_rgb
@@ -163,5 +164,6 @@ def load(state_dict: StateDict) -> ImageModelDescriptor[DDColor]:
         scale=1,
         input_channels=1,
         output_channels=3,
+        tiling=ModelTiling.INTERNAL,
         call_fn=_call,
     )

--- a/src/spandrel/architectures/SCUNet/__init__.py
+++ b/src/spandrel/architectures/SCUNet/__init__.py
@@ -1,5 +1,6 @@
 from ...__helpers.model_descriptor import (
     ImageModelDescriptor,
+    ModelTiling,
     SizeRequirements,
     StateDict,
 )
@@ -45,4 +46,5 @@ def load(state_dict: StateDict) -> ImageModelDescriptor[SCUNet]:
         input_channels=in_nc,
         output_channels=in_nc,
         size_requirements=SizeRequirements(minimum=16),
+        tiling=ModelTiling.DISCOURAGED,
     )

--- a/tests/__snapshots__/test_CodeFormer.ambr
+++ b/tests/__snapshots__/test_CodeFormer.ambr
@@ -11,5 +11,6 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_Compact.ambr
+++ b/tests/__snapshots__/test_Compact.ambr
@@ -13,6 +13,7 @@
       '64nf',
       '16nc',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_Compact_realesr_general_x4v3
@@ -29,5 +30,6 @@
       '64nf',
       '32nc',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_DAT.ambr
+++ b/tests/__snapshots__/test_DAT.ambr
@@ -17,6 +17,7 @@
       '2.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_S_x3
@@ -37,6 +38,7 @@
       '2.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_S_x4
@@ -57,6 +59,7 @@
       '2.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_tags
@@ -77,6 +80,7 @@
       '2.0ef',
       '3conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_tags.1
@@ -97,6 +101,7 @@
       '2.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_tags.2
@@ -117,6 +122,7 @@
       '4.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_tags.3
@@ -137,6 +143,7 @@
       '2.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DAT_x4
@@ -157,5 +164,6 @@
       '4.0ef',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_DDColor.ambr
+++ b/tests/__snapshots__/test_DDColor.ambr
@@ -16,5 +16,6 @@
       '512nf',
       '100nq 3ns 9dl',
     ]),
+    tiling=<ModelTiling.INTERNAL: 3>,
   )
 # ---

--- a/tests/__snapshots__/test_DITN.ambr
+++ b/tests/__snapshots__/test_DITN.ambr
@@ -12,6 +12,7 @@
     tags=list([
       '60dim',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_DITN_Real_x4
@@ -27,5 +28,6 @@
     tags=list([
       '60dim',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -13,6 +13,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_BSRGAN_2x
@@ -29,6 +30,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_ESRGAN_community
@@ -45,6 +47,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_ESRGAN_community_2x
@@ -61,6 +64,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_ESRGAN_community_4x
@@ -77,6 +81,7 @@
       '32nf',
       '12nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_ESRGAN_community_8x
@@ -93,6 +98,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealESRGAN_x2plus
@@ -109,6 +115,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealESRGAN_x4plus
@@ -125,6 +132,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealESRGAN_x4plus_anime_6B
@@ -141,6 +149,7 @@
       '64nf',
       '6nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealESRNet_x4plus
@@ -157,6 +166,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealSR_DPED
@@ -173,6 +183,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_RealSR_JPEG
@@ -189,5 +200,6 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_FBCNN.ambr
+++ b/tests/__snapshots__/test_FBCNN.ambr
@@ -11,6 +11,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_FBCNN_gray
@@ -25,5 +26,6 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_FeMaSR.ambr
+++ b/tests/__snapshots__/test_FeMaSR.ambr
@@ -11,6 +11,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_FeMaSR_2x
@@ -25,6 +26,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_FeMaSR_4x
@@ -39,5 +41,6 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_GFPGAN.ambr
+++ b/tests/__snapshots__/test_GFPGAN.ambr
@@ -11,6 +11,7 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_GFPGAN_1_3
@@ -25,6 +26,7 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_GFPGAN_1_4
@@ -39,5 +41,6 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_GRLIR.ambr
+++ b/tests/__snapshots__/test_GRLIR.ambr
@@ -15,6 +15,7 @@
       'w16df4',
       's32x64',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_GRLIR_sr_grl_tiny_c3x3
@@ -33,6 +34,7 @@
       'w32df4',
       's64x64',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_GRLIR_sr_grl_tiny_c3x4
@@ -51,5 +53,6 @@
       'w32df4',
       's64x64',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_HAT.ambr
+++ b/tests/__snapshots__/test_HAT.ambr
@@ -16,6 +16,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_4x
@@ -35,6 +36,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_L_4x
@@ -54,6 +56,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_S_2x
@@ -73,6 +76,7 @@
       '144dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_S_3x
@@ -92,6 +96,7 @@
       '144dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_S_4x
@@ -111,6 +116,7 @@
       '144dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_community1
@@ -130,6 +136,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_HAT_community2
@@ -149,5 +156,6 @@
       '144dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_LaMa.ambr
+++ b/tests/__snapshots__/test_LaMa.ambr
@@ -11,5 +11,6 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_MAT.ambr
+++ b/tests/__snapshots__/test_MAT.ambr
@@ -11,5 +11,6 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_MMRealSR.ambr
+++ b/tests/__snapshots__/test_MMRealSR.ambr
@@ -13,6 +13,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_MMRealSRGAN_ModulationBest
@@ -29,6 +30,7 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_MMRealSRNet
@@ -45,5 +47,6 @@
       '64nf',
       '23nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_OmniSR.ambr
+++ b/tests/__snapshots__/test_OmniSR.ambr
@@ -14,6 +14,7 @@
       'w8',
       '5nr',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_OmniSR_community2
@@ -31,6 +32,7 @@
       'w8',
       '5nr',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_OmniSR_official_x2
@@ -48,6 +50,7 @@
       'w8',
       '5nr',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_OmniSR_official_x3
@@ -65,6 +68,7 @@
       'w8',
       '5nr',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_OmniSR_official_x4
@@ -82,5 +86,6 @@
       'w8',
       '5nr',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_RestoreFormer.ambr
+++ b/tests/__snapshots__/test_RestoreFormer.ambr
@@ -11,5 +11,6 @@
     supports_half=False,
     tags=list([
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_SCUNet.ambr
+++ b/tests/__snapshots__/test_SCUNet.ambr
@@ -11,6 +11,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.DISCOURAGED: 2>,
   )
 # ---
 # name: test_SCUNet_color_GAN
@@ -25,6 +26,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.DISCOURAGED: 2>,
   )
 # ---
 # name: test_SCUNet_color_RSNR
@@ -39,6 +41,7 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.DISCOURAGED: 2>,
   )
 # ---
 # name: test_SCUNet_gray_25
@@ -53,5 +56,6 @@
     supports_half=True,
     tags=list([
     ]),
+    tiling=<ModelTiling.DISCOURAGED: 2>,
   )
 # ---

--- a/tests/__snapshots__/test_SRFormer.ambr
+++ b/tests/__snapshots__/test_SRFormer.ambr
@@ -15,6 +15,7 @@
       '60dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SRFormer_SRx2_DF2K
@@ -33,6 +34,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SRFormer_SRx4_DF2K
@@ -51,5 +53,6 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_SwiftSRGAN.ambr
+++ b/tests/__snapshots__/test_SwiftSRGAN.ambr
@@ -13,6 +13,7 @@
       '64nf',
       '16nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SwiftSRGAN_4x
@@ -29,5 +30,6 @@
       '64nf',
       '16nb',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_Swin2SR.ambr
+++ b/tests/__snapshots__/test_Swin2SR.ambr
@@ -15,6 +15,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_Swin2SR_4x
@@ -33,6 +34,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_Swin2SR_compressed
@@ -51,6 +53,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_Swin2SR_jpeg
@@ -69,6 +72,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_Swin2SR_lightweight_2x
@@ -87,5 +91,6 @@
       '60dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---

--- a/tests/__snapshots__/test_SwinIR.ambr
+++ b/tests/__snapshots__/test_SwinIR.ambr
@@ -16,6 +16,7 @@
       '240dim',
       '3conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SwinIR_M_s48w8_4x
@@ -35,6 +36,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SwinIR_M_s64w8_2x
@@ -54,6 +56,7 @@
       '180dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---
 # name: test_SwinIR_S_2x
@@ -73,5 +76,6 @@
       '60dim',
       '1conv',
     ]),
+    tiling=<ModelTiling.SUPPORTED: 1>,
   )
 # ---


### PR DESCRIPTION
This PR adds information about how to best tile input images. I'm not sure whether I covered everything. My thinking as follows:

- `SUPPORTED`: Most archs support tiling no problem, so do whatever. E.g. ESRGAN. 
- `DISCOURAGED`: Some archs technically support tiling, but doing so might cause heavy artifacts. E.g. SCUNet.
- `INTERNAL`: The arch does tiling (or similar) internally, so you shouldn't do any tiling yourself and just leave it to the arch. E.g. DDColor.