### PR TITLE
Fix ESRGAN+, remove ESRGAN-2c2, and improved parameter detection

### DIFF
--- a/src/spandrel/architectures/ESRGAN/arch/RRDB.py
+++ b/src/spandrel/architectures/ESRGAN/arch/RRDB.py
@@ -19,7 +19,6 @@ class RRDBNet(nn.Module):
         num_filters: int = 64,
         num_blocks: int = 23,
         scale: int = 4,
-        c2x2: bool = False,
         plus: bool = False,
         shuffle_factor: int | None = None,
         norm=None,
@@ -60,7 +59,6 @@ class RRDBNet(nn.Module):
                 out_nc=num_filters,
                 upscale_factor=3,
                 act_type=act,
-                c2x2=c2x2,
             )
         else:
             upsample_blocks = [
@@ -68,7 +66,6 @@ class RRDBNet(nn.Module):
                     in_nc=num_filters,
                     out_nc=num_filters,
                     act_type=act,
-                    c2x2=c2x2,
                 )
                 for _ in range(int(math.log(scale, 2)))
             ]
@@ -81,7 +78,6 @@ class RRDBNet(nn.Module):
                 kernel_size=3,
                 norm_type=None,
                 act_type=None,
-                c2x2=c2x2,
             ),
             B.ShortcutBlock(
                 B.sequential(
@@ -98,7 +94,6 @@ class RRDBNet(nn.Module):
                             act_type=act,
                             mode="CNA",
                             plus=plus,
-                            c2x2=c2x2,
                         )
                         for _ in range(num_blocks)
                     ],
@@ -110,7 +105,6 @@ class RRDBNet(nn.Module):
                         norm_type=norm,
                         act_type=None,
                         mode=mode,
-                        c2x2=c2x2,
                     ),
                 )
             ),
@@ -122,7 +116,6 @@ class RRDBNet(nn.Module):
                 kernel_size=3,
                 norm_type=None,
                 act_type=act,
-                c2x2=c2x2,
             ),
             # hr_conv1
             B.conv_block(
@@ -131,7 +124,6 @@ class RRDBNet(nn.Module):
                 kernel_size=3,
                 norm_type=None,
                 act_type=None,
-                c2x2=c2x2,
             ),
         )
 

--- a/src/spandrel/architectures/__arch_helpers/block.py
+++ b/src/spandrel/architectures/__arch_helpers/block.py
@@ -156,18 +156,12 @@ def conv_block(
     norm_type: str | None = None,
     act_type: str | None = "relu",
     mode: ConvMode = "CNA",
-    c2x2=False,
 ):
     """
     Conv layer with padding, normalization, activation
     mode: CNA --> Conv -> Norm -> Act
         NAC --> Norm -> Act --> Conv (Identity Mappings in Deep Residual Networks, ECCV16)
     """
-
-    if c2x2:
-        return conv_block_2c2(
-            in_nc, out_nc, act_type=act_type if act_type is not None else "relu"
-        )
 
     assert mode in ("CNA", "NAC", "CNAC"), f"Wrong conv mode [{mode:s}]"
     padding = get_valid_padding(kernel_size, dilation)
@@ -295,7 +289,6 @@ class RRDB(nn.Module):
         _convtype="Conv2D",
         _spectral_norm=False,
         plus=False,
-        c2x2=False,
     ):
         super().__init__()
         self.RDB1 = ResidualDenseBlock_5C(
@@ -309,7 +302,6 @@ class RRDB(nn.Module):
             act_type,
             mode,
             plus=plus,
-            c2x2=c2x2,
         )
         self.RDB2 = ResidualDenseBlock_5C(
             nf,
@@ -322,7 +314,6 @@ class RRDB(nn.Module):
             act_type,
             mode,
             plus=plus,
-            c2x2=c2x2,
         )
         self.RDB3 = ResidualDenseBlock_5C(
             nf,
@@ -335,7 +326,6 @@ class RRDB(nn.Module):
             act_type,
             mode,
             plus=plus,
-            c2x2=c2x2,
         )
 
     def forward(self, x):
@@ -379,7 +369,6 @@ class ResidualDenseBlock_5C(nn.Module):
         act_type="leakyrelu",
         mode: ConvMode = "CNA",
         plus=False,
-        c2x2=False,
     ):
         super().__init__()
 
@@ -397,7 +386,6 @@ class ResidualDenseBlock_5C(nn.Module):
             norm_type=norm_type,
             act_type=act_type,
             mode=mode,
-            c2x2=c2x2,
         )
         self.conv2 = conv_block(
             nf + gc,
@@ -409,7 +397,6 @@ class ResidualDenseBlock_5C(nn.Module):
             norm_type=norm_type,
             act_type=act_type,
             mode=mode,
-            c2x2=c2x2,
         )
         self.conv3 = conv_block(
             nf + 2 * gc,
@@ -421,7 +408,6 @@ class ResidualDenseBlock_5C(nn.Module):
             norm_type=norm_type,
             act_type=act_type,
             mode=mode,
-            c2x2=c2x2,
         )
         self.conv4 = conv_block(
             nf + 3 * gc,
@@ -433,7 +419,6 @@ class ResidualDenseBlock_5C(nn.Module):
             norm_type=norm_type,
             act_type=act_type,
             mode=mode,
-            c2x2=c2x2,
         )
         if mode == "CNA":
             last_act = None
@@ -449,7 +434,6 @@ class ResidualDenseBlock_5C(nn.Module):
             norm_type=norm_type,
             act_type=last_act,
             mode=mode,
-            c2x2=c2x2,
         )
 
     def forward(self, x):
@@ -519,7 +503,6 @@ def upconv_block(
     norm_type: str | None = None,
     act_type="relu",
     mode="nearest",
-    c2x2=False,
 ):
     # Up conv
     # described in https://distill.pub/2016/deconv-checkerboard/
@@ -533,6 +516,5 @@ def upconv_block(
         pad_type=pad_type,
         norm_type=norm_type,
         act_type=act_type,
-        c2x2=c2x2,
     )
     return sequential(upsample, conv)

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -1,6 +1,26 @@
-from spandrel.architectures.ESRGAN import RRDBNet
+from spandrel.architectures.ESRGAN import RRDBNet, load
 
-from .util import ModelFile, TestImage, assert_image_inference, disallowed_props
+from .util import (
+    ModelFile,
+    TestImage,
+    assert_image_inference,
+    assert_loads_correctly,
+    disallowed_props,
+)
+
+
+def test_ESRGAN_load():
+    assert_loads_correctly(
+        load,
+        lambda: RRDBNet(in_nc=3, out_nc=3, num_filters=64, num_blocks=23, scale=4),
+        lambda: RRDBNet(in_nc=1, out_nc=3, num_filters=32, num_blocks=11, scale=2),
+        lambda: RRDBNet(in_nc=1, out_nc=1, num_filters=64, num_blocks=23, scale=1),
+        lambda: RRDBNet(in_nc=4, out_nc=4, num_filters=64, num_blocks=23, scale=8),
+        lambda: RRDBNet(scale=4, plus=True),
+        condition=lambda a, b: (
+            a.scale == b.scale and a.shuffle_factor == b.shuffle_factor
+        ),
+    )
 
 
 def test_ESRGAN_community(snapshot):


### PR DESCRIPTION
Changes:
- ESRGAN+ model now load correctly.
- I removed the ESRGAN-2c2 code.
- I generally improved the parameter detection a little. The code is now separate from the new arch -> old arch conversion.