### PR TITLE
GFPGANv1Clean: assign missing fields

### DIFF
--- a/src/spandrel/architectures/GFPGAN/arch/gfpganv1_clean_arch.py
+++ b/src/spandrel/architectures/GFPGAN/arch/gfpganv1_clean_arch.py
@@ -203,6 +203,9 @@ class GFPGANv1Clean(nn.Module):
         sft_half=True,
     ):
         super().__init__()
+        self.different_w = different_w
+        self.input_is_latent = input_is_latent
+        self.num_style_feat = num_style_feat
 
         unet_narrow = narrow * 0.5  # by default, use a half of input channels
         channels = {


### PR DESCRIPTION
These field were never assigned even if they're accessed in `forward()`.

I think there might be something else wrong with the GFPGAN models (I'm working on replacing stable-diffusion-webui's upscalers with this repo in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14425), but this was an obvious `AttributeError` bug.