### PR TITLE
Packaging improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=46.4.0", "wheel", "build"]
+requires = ["setuptools>=46.4.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -34,7 +34,7 @@ dependencies = ["torch", "torchvision", "safetensors", "numpy", "einops"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-build = ["setuptools>=46.4.0", "wheel", "build", "twine"]
+build = ["build", "twine"]
 lint = ["ruff==0.1.6"]
 typecheck = ["pyright==1.1.335"]
 test = ["pytest==7.4.0", "syrupy==4.6.0", "opencv-python==4.8.1.78"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,11 @@ lint = ["ruff==0.1.6"]
 typecheck = ["pyright==1.1.335"]
 test = ["pytest==7.4.0", "syrupy==4.6.0", "opencv-python==4.8.1.78"]
 
-# [tool.setuptools.dynamic]
-# version = { attr = "spandrel.VERSION" }
+[tool.setuptools]
+license-files = ["LICENSE"]
+
+[tool.setuptools.dynamic]
+version = { attr = "spandrel.__version__" }
 
 [tool.ruff]
 # Same as Black.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spandrel"
 authors = [{ name = "chaiNNer team" }]
 description = "Give your project support for a variety of PyTorch model architectures, including auto-detecting model architecture from just .pth files. spandrel gives you arch support."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 keywords = [
     "spandrel",
     "pytorch architecture",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[metadata]
-version = attr: spandrel.__version__
-license_files = LICENSE


### PR DESCRIPTION
* `requires-python` doesn't need an upper limit; the package works with a nightly version of Torch on Python 3.12, but couldn't otherwise be installed without `--ignore-requires-python`.
* Things configured in `setup.cfg` can be configured in `pyproject.toml`.
* `wheel` and `build` shouldn't be PEP517 build requirements; similarly, build requirements shouldn't be in the `build` extra used by the release step, since `python -m build .` will install them in the isolated venv.