### PR TITLE
Lint with pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,19 +18,6 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    formatting:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.11'
-                  cache: 'pip'
-            - run: pip install .[lint] --extra-index-url https://download.pytorch.org/whl/cpu
-            - run: ruff format src --check
-            - run: ruff format tests --check
-            - run: ruff format scripts --check
-
     lint:
         runs-on: ubuntu-latest
         steps:
@@ -39,10 +26,9 @@ jobs:
               with:
                   python-version: '3.11'
                   cache: 'pip'
-            - run: pip install .[lint] --extra-index-url https://download.pytorch.org/whl/cpu
-            - run: ruff check src
-            - run: ruff check tests
-            - run: ruff check scripts
+            - uses: pre-commit/action@v3.0.0
+              env:
+                RUFF_OUTPUT_FORMAT: github
 
     pyright:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.1.9"
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+          - --unsafe-fixes
+      - id: ruff-format
+        args:
+          - --quiet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ We use [ruff](https://docs.astral.sh/ruff/) for formatting and linting and [pyri
 - Ruff formatting: `ruff format src tests`
 - PyRight: `pyright src tests`
 
+#### `pre-commit`
+
+You can also use [pre-commit](https://pre-commit.com/) to automatically run Ruff before committing.
+To do so, install pre-commit (`pip install pre-commit`) and run `pre-commit install` in the root directory of the repo.
+You can also run `pre-commit run --all-files` to run pre-commit on all files in the repo.
+
 ### Project Structure
 
 The project is structured as follows:


### PR DESCRIPTION
This PR proposes to

* add a `.pre-commit-config.yaml` file to make it possible to use https://pre-commit.com/ to run the Ruff lint and format step (i.e. have everything checked and fixed at commit time (if so desired)).
* for consistency's sake, switch CI to do that too using [`pre-commit/action`](https://github.com/pre-commit/action).
  * on that note, it sets `RUFF_OUTPUT_FORMAT` to `"github"`, so Ruff outputs warnings in a form that makes GitHub Actions print them quite prettily
* <del>add the basic `pre-commit-hooks` hooks to enforce some hygienic line-ending rules (and fixes the handful of issues).</del>

This shouldn't affect regular development without `pre-commit` other than having to remember to keep the Ruff version in sync between the `lint` extra and the pre-commit config.