### PR TITLE
Improved parameter detection for CRAFT

### DIFF
--- a/tests/test_CRAFT.py
+++ b/tests/test_CRAFT.py
@@ -24,10 +24,16 @@ def test_CRAFT_load():
         lambda: CRAFT(upscale=2),
         lambda: CRAFT(upscale=3),
         lambda: CRAFT(upscale=4),
+        lambda: CRAFT(qkv_bias=False),
+        lambda: CRAFT(split_size_0=4, split_size_1=16),
+        lambda: CRAFT(split_size_0=10, split_size_1=12),
+        lambda: CRAFT(resi_connection="identity"),
         condition=lambda a, b: (
             a.num_layers == b.num_layers
             and a.upscale == b.upscale
             and a.embed_dim == b.embed_dim
+            and a.split_size == b.split_size
+            and a.window_size == b.window_size
         ),
     )
 


### PR DESCRIPTION
It might seem like a lot changed, but that's only because I reordered the code. Otherwise, I changed the following:

- Simpler detection for `depths` and `num_heads`.
- Detect `resi_connection` and `qkv_bias`.
- Detect `split_size_0` and `split_size_1`. This was pretty involved, since the code that determines the shapes from which I got `a` and `b` is pretty complex.