### PR TITLE
Use CPU PyTorch in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install .[docs]
+      - run: pip install .[docs] --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Build the website
         run: pydoctor --project-url=https://github.com/$GITHUB_REPOSITORY --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA
       - name: Upload artifact

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   python-version: '3.11'
                   cache: 'pip'
-            - run: pip install .[lint]
+            - run: pip install .[lint] --extra-index-url https://download.pytorch.org/whl/cpu
             - run: ruff format src --check
             - run: ruff format tests --check
             - run: ruff format scripts --check
@@ -39,7 +39,7 @@ jobs:
               with:
                   python-version: '3.11'
                   cache: 'pip'
-            - run: pip install .[lint]
+            - run: pip install .[lint] --extra-index-url https://download.pytorch.org/whl/cpu
             - run: ruff check src
             - run: ruff check tests
             - run: ruff check scripts
@@ -52,7 +52,7 @@ jobs:
               with:
                   python-version: '3.11'
                   cache: 'pip'
-            - run: pip install .[typecheck,test]
+            - run: pip install .[typecheck,test] --extra-index-url https://download.pytorch.org/whl/cpu
             - run: pyright src/
             - run: pyright tests/
             - run: pyright scripts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install .[build]
+        run: pip install .[build] --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: 'pip'
-            - run: pip install .[test]
+            - run: pip install .[test] --extra-index-url https://download.pytorch.org/whl/cpu
             - name: Cache models
               id: cache-models
               uses: actions/cache@v3
@@ -50,6 +50,6 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
-            - run: pip install .[docs]
+            - run: pip install .[docs] --extra-index-url https://download.pytorch.org/whl/cpu
             - run: pydoctor
 


### PR DESCRIPTION
Similar to what I did in [2429](https://github.com/chaiNNer-org/chaiNNer/pull/2429), I made CI use the cpu of pytorch here. Why they chose to make CUDA the default only on linux I have no idea...