### PR TITLE
scripts: avoid `sys.path` hacks; simplify

### DIFF
--- a/scripts/dump_dummy.py
+++ b/scripts/dump_dummy.py
@@ -17,23 +17,16 @@ VSCode is the recommended IDE for this task.
 After you edited the function, run this script, and it will dump the state dict
 of the dummy model to `dump.yml`.
 
-    python scripts/dump_dummy.py
+    python -m scripts.dump_dummy
 
 For more detail on the dump itself, see the docs of `dump_state_dict.py`.
 """
 
-
 import inspect
-import os
-import sys
 from textwrap import dedent
 
 import torch
-
-# This hack is necessary to make our module import
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
-
-from dump_state_dict import dump
+from scripts.dump_state_dict import dump
 
 from spandrel.architectures import SCUNet
 
@@ -43,7 +36,7 @@ def create_dummy() -> torch.nn.Module:
     return SCUNet.SCUNet()
 
 
-if __name__ == "__main__":
+def main():
     net = create_dummy()
     state = net.state_dict()
 
@@ -55,3 +48,7 @@ if __name__ == "__main__":
         source = source[7:]
 
     dump(state, source)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dump_state_dict.py
+++ b/scripts/dump_state_dict.py
@@ -15,7 +15,7 @@ similar models do the following:
 
 Usage:
 
-    python scripts/dump_state_dict.py /path/to/model.pth
+    python -m scripts.dump_state_dict /path/to/model.pth
 
 Example `dump.yml`:
 
@@ -41,23 +41,15 @@ state dict.
 
 from __future__ import annotations
 
-import os
 import sys
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Iterable, TypeVar
 
 from torch import Tensor
 
-# This hack is necessary to make our module import
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
-
-from spandrel import ModelLoader  # noqa: E402
+from spandrel import ModelLoader
 
 State = Dict[str, object]
-
-
-def load_state(file: str) -> State:
-    return ModelLoader().load_state_dict_from_file(file)
 
 
 def indent(lines: list[str], indentation: str = "  "):
@@ -181,9 +173,13 @@ def dump(state: dict[str, Any], comment: str, file: str = "dump.yml"):
     print(f"Dumped {len(state)} keys to {file}")
 
 
-if __name__ == "__main__":
+def main() -> None:
     file = sys.argv[1]
     print(f"Input file: {file}")
-    state = load_state(file)
+    state = ModelLoader().load_state_dict_from_file(file)
 
     dump(state, file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dump_state_dict.py
+++ b/scripts/dump_state_dict.py
@@ -41,7 +41,7 @@ state dict.
 
 from __future__ import annotations
 
-import sys
+import argparse
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Iterable, TypeVar
 
@@ -174,11 +174,14 @@ def dump(state: dict[str, Any], comment: str, file: str = "dump.yml"):
 
 
 def main() -> None:
-    file = sys.argv[1]
+    ap = argparse.ArgumentParser()
+    ap.add_argument("file", help="Path to model file")
+    ap.add_argument("-o", "--output", help="Output file", default="dump.yml")
+    args = ap.parse_args()
+    file = args.file
     print(f"Input file: {file}")
     state = ModelLoader().load_state_dict_from_file(file)
-
-    dump(state, file)
+    dump(state, comment=file, file=args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR removes the `sys.path` hacks from the `scripts/`. It should work as-is, but as usual when working on a library, you can also `pip install -e .` to make sure `src/spandrel` is editable and in your env's paths.

You will need to run these scripts with [`python -m`](https://docs.python.org/3.12/using/cmdline.html#cmdoption-m) henceforth, though, but that's really good hygiene anyway, as you're forced to use proper imports (see `from scripts.dump_state_dict import` instead of `from dump_state_dict import`) that don't depend on the cwd or `PYTHONPATH`. 

It also simplifies and idiomaticizes (what a word!) `dump_state_dict` a bit – I checked that the output is the same aside from less trailing whitespaces in certain lines.