### PR TITLE
tests: avoid sys.path hacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,13 @@ ignore = [
 "**/tests/**/*" = ["N802", "ANN"]
 
 [tool.pytest.ini_options]
-filterwarnings = ["ignore::DeprecationWarning", "ignore::UserWarning"]
+filterwarnings = [
+  "ignore::DeprecationWarning",
+  "ignore::UserWarning",
+]
+pythonpath = [
+  "src",
+]
 
 [tool.pydoctor]
 project-name = "spandrel"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-import os
-import sys
-
-# I fucking hate python. This hack is necessary to make our module import
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))


### PR DESCRIPTION
Don't manually hack `sys.path` in `tests/__init__.py`; instead [do this](https://stackoverflow.com/a/50156706/51685). (`pip install -e .` before running tests will have the same end effect.)