### PR TITLE
arch: remove torch.load calls

### DIFF
--- a/src/spandrel/architectures/CodeFormer/arch/codeformer.py
+++ b/src/spandrel/architectures/CodeFormer/arch/codeformer.py
@@ -339,6 +339,8 @@ class VQAutoEncoder(nn.Module):
         gumbel_kl_weight=1e-8,
         model_path=None,
     ):
+        if model_path:
+            raise NotImplementedError(f"Got a non-empty {model_path=}")
         super().__init__()
         self.in_channels = 3
         self.nf = nf
@@ -377,21 +379,6 @@ class VQAutoEncoder(nn.Module):
         self.generator = Generator(
             nf, ch_mult, res_blocks, img_size, attn_resolutions, emb_dim
         )
-
-        if model_path is not None:
-            chkpt = torch.load(model_path, map_location="cpu")
-            if "params_ema" in chkpt:
-                self.load_state_dict(
-                    torch.load(model_path, map_location="cpu")["params_ema"]
-                )
-                # print(f"vqgan is loaded from: {model_path} [params_ema]")
-            elif "params" in chkpt:
-                self.load_state_dict(
-                    torch.load(model_path, map_location="cpu")["params"]
-                )
-                # print(f"vqgan is loaded from: {model_path} [params]")
-            else:
-                raise ValueError("Wrong params!")
 
     def forward(self, x):
         x = self.encoder(x)

--- a/src/spandrel/architectures/FeMaSR/arch/vgg_arch.py
+++ b/src/spandrel/architectures/FeMaSR/arch/vgg_arch.py
@@ -1,11 +1,9 @@
-import os
 from collections import OrderedDict
 
 import torch
 from torch import nn as nn
 from torchvision.models import vgg as vgg  # type: ignore
 
-VGG_PRETRAIN_PATH = "experiments/pretrained_models/vgg19-dcbb9e9d.pth"
 NAMES = {
     "vgg11": [
         "conv1_1",
@@ -200,14 +198,7 @@ class VGGFeatureExtractor(nn.Module):
             if idx > max_idx:
                 max_idx = idx
 
-        if os.path.exists(VGG_PRETRAIN_PATH):
-            vgg_net = getattr(vgg, vgg_type)(pretrained=False)
-            state_dict = torch.load(
-                VGG_PRETRAIN_PATH, map_location=lambda storage, loc: storage
-            )
-            vgg_net.load_state_dict(state_dict)
-        else:
-            vgg_net = getattr(vgg, vgg_type)(pretrained=True)
+        vgg_net = getattr(vgg, vgg_type)(pretrained=True)
 
         features = vgg_net.features[: max_idx + 1]
 

--- a/src/spandrel/architectures/GFPGAN/arch/gfpgan_bilinear_arch.py
+++ b/src/spandrel/architectures/GFPGAN/arch/gfpgan_bilinear_arch.py
@@ -268,13 +268,10 @@ class GFPGANBilinear(nn.Module):
             sft_half=sft_half,
         )
 
-        # load pre-trained stylegan2 model if necessary
         if decoder_load_path:
-            self.stylegan_decoder.load_state_dict(
-                torch.load(
-                    decoder_load_path, map_location=lambda storage, loc: storage
-                )["params_ema"]
-            )
+            # Refuse to attempt to load a decoder here
+            raise NotImplementedError(f"Got a non-empty {decoder_load_path=}")
+
         # fix decoder without updating params
         if fix_decoder:
             for _, param in self.stylegan_decoder.named_parameters():

--- a/src/spandrel/architectures/GFPGAN/arch/gfpganv1_arch.py
+++ b/src/spandrel/architectures/GFPGAN/arch/gfpganv1_arch.py
@@ -368,13 +368,10 @@ class GFPGANv1(nn.Module):
             sft_half=sft_half,
         )
 
-        # load pre-trained stylegan2 model if necessary
         if decoder_load_path:
-            self.stylegan_decoder.load_state_dict(
-                torch.load(
-                    decoder_load_path, map_location=lambda storage, loc: storage
-                )["params_ema"]
-            )
+            # Refuse to attempt to load a decoder here
+            raise NotImplementedError(f"Got a non-empty {decoder_load_path=}")
+
         # fix decoder without updating params
         if fix_decoder:
             for _, param in self.stylegan_decoder.named_parameters():

--- a/src/spandrel/architectures/GFPGAN/arch/gfpganv1_clean_arch.py
+++ b/src/spandrel/architectures/GFPGAN/arch/gfpganv1_clean_arch.py
@@ -265,13 +265,10 @@ class GFPGANv1Clean(nn.Module):
             sft_half=sft_half,
         )
 
-        # load pre-trained stylegan2 model if necessary
         if decoder_load_path:
-            self.stylegan_decoder.load_state_dict(
-                torch.load(
-                    decoder_load_path, map_location=lambda storage, loc: storage
-                )["params_ema"]
-            )
+            # Refuse to attempt to load a decoder here
+            raise NotImplementedError(f"Got a non-empty {decoder_load_path=}")
+
         # fix decoder without updating params
         if fix_decoder:
             for _, param in self.stylegan_decoder.named_parameters():


### PR DESCRIPTION
Architecture code should not be loading any extra data from an arbitrary file without safe unpickling.