### PR TITLE
Allow strings for Torch devices, like Torch does

### DIFF
--- a/src/spandrel/__helpers/loader.py
+++ b/src/spandrel/__helpers/loader.py
@@ -18,9 +18,11 @@ class ModelLoader:
 
     def __init__(
         self,
-        device: torch.device | None = None,
+        device: str | torch.device | None = None,
         registry: ArchRegistry = MAIN_REGISTRY,
     ):
+        if isinstance(device, str):
+            device = torch.device(device)
         self.device: torch.device = device or torch.device("cpu")
         self.registry: ArchRegistry = registry
         """

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -195,7 +195,7 @@ class ModelBase(ABC, Generic[T]):
         """
         ...
 
-    def to(self, device: torch.device):
+    def to(self, device: str | torch.device):
         """
         Moves the parameters and buffers of the underlying module to the given device.
         """


### PR DESCRIPTION
As discussed in https://github.com/chaiNNer-org/spandrel/pull/111#issuecomment-1874572986.

Torch's `to` [also allows integers](https://github.com/pytorch/pytorch/blob/295bdaafb7a056c4df13e410229dd808c28e7a75/torch/_prims_common/__init__.py#L55) but I think that's taking things too far.