### PR TITLE
Add `device` property for models

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -195,9 +195,24 @@ class ModelBase(ABC, Generic[T]):
         """
         ...
 
+    @property
+    def device(self) -> torch.device:
+        """
+        The device of the underlying module.
+
+        Use `to` to move the model to a different device.
+        """
+        # This makes the following assumptions:
+        # - The model is on a single device
+        # - The model has at least one parameter
+        # Both are true for all models implemented in Spandrel.
+        return next(self.model.parameters()).device
+
     def to(self, device: str | torch.device):
         """
         Moves the parameters and buffers of the underlying module to the given device.
+
+        Use `device` to get the current device of the model.
         """
         self.model.to(device)
         return self

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -206,6 +206,7 @@ class ModelBase(ABC, Generic[T]):
         # - The model is on a single device
         # - The model has at least one parameter
         # Both are true for all models implemented in Spandrel.
+        # https://stackoverflow.com/questions/58926054/how-to-get-the-device-type-of-a-pytorch-module-conveniently
         return next(self.model.parameters()).device
 
     def to(self, device: str | torch.device):

--- a/tests/util.py
+++ b/tests/util.py
@@ -110,7 +110,7 @@ class ModelFile:
         return file
 
 
-disallowed_props = props("model", "state_dict")
+disallowed_props = props("model", "state_dict", "device")
 
 
 @contextmanager


### PR DESCRIPTION
This adds a `device` property to conveniently get the device of a model.