### PR TITLE
Update CONTRIBUTING.md to suggest `pip install -e .`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document will explain how to [get started](#getting-started) and give a gui
 Before you can start with the actual development, you need to set up the project.
 
 1. Fork and clone the repository. ([GitHub guide](https://docs.github.com/en/get-started/quickstart/fork-a-repo))
-2. Install dependencies: `pip install .`. (One of our dependencies, `torch`, is huge (>2GB) and might need a few minutes to download depending on your internet speed.)
+2. Install dependencies: `pip install -e .`. (One of our dependencies, `torch`, is huge (>2GB) and might need a few minutes to download depending on your internet speed.)
 
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) as your IDE. It has great support for Python and is easy to set up. If you do, please install the following extensions: PyLance, Ruff, and Code Spell Checker. VSCode should show you a notification when you first open the project to install these extensions.
 


### PR DESCRIPTION
As suggested by @akx [here](https://github.com/chaiNNer-org/spandrel/pull/106#issue-2062387313), this makes a few things easier. It's also great for testing spandrel in chainner, because `npm run dev` will just use the current local source of spandrel.