### PR TITLE
Save Real-CUGAN models correctly

### DIFF
--- a/src/spandrel/architectures/RealCUGAN/__init__.py
+++ b/src/spandrel/architectures/RealCUGAN/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Literal
 
+import torch
+
 from ...__helpers.model_descriptor import (
     ImageModelDescriptor,
     SizeRequirements,
@@ -22,7 +24,7 @@ def load(
     if "pro" in state_dict:
         pro = True
         tags.append("pro")
-        del state_dict["pro"]
+        state_dict["pro"] = torch.zeros(1)
 
     if "conv_final.weight" in state_dict:
         # UpCunet4x

--- a/tests/test_RealCUGAN.py
+++ b/tests/test_RealCUGAN.py
@@ -14,10 +14,14 @@ def test_RealCUGAN_load():
         load,
         lambda: UpCunet2x(in_channels=3, out_channels=3),
         lambda: UpCunet2x(in_channels=1, out_channels=4),
+        lambda: UpCunet2x(pro=True),
         lambda: UpCunet3x(in_channels=3, out_channels=3),
         lambda: UpCunet3x(in_channels=1, out_channels=4),
+        lambda: UpCunet3x(pro=True),
         lambda: UpCunet4x(in_channels=3, out_channels=3),
         lambda: UpCunet4x(in_channels=1, out_channels=3),
+        lambda: UpCunet4x(pro=True),
+        condition=lambda a, b: (a.is_pro == b.is_pro),
     )
 
 


### PR DESCRIPTION
Fixes #89.

As I described in #89, I used an optional buffer called "pro" to save a "pro" key in the state dict. This ensures that the key is present only in pro models.

Since the official code only checks for the existence of the "pro" key and not its value, it doesn't matter we store a tensor instead of an int. So this solution is compatible with official arch code.