### PR TITLE
Fix ESRGAN size requirement

### DIFF
--- a/src/spandrel/architectures/ESRGAN/__init__.py
+++ b/src/spandrel/architectures/ESRGAN/__init__.py
@@ -193,5 +193,5 @@ def load(state: StateDict) -> ImageModelDescriptor[RRDBNet]:
         scale=scale,
         input_channels=in_nc,
         output_channels=out_nc,
-        size_requirements=SizeRequirements(multiple_of=4),
+        size_requirements=SizeRequirements(multiple_of=4 if shuffle_factor else 1),
     )

--- a/src/spandrel/architectures/ESRGAN/__init__.py
+++ b/src/spandrel/architectures/ESRGAN/__init__.py
@@ -5,7 +5,11 @@ import math
 import re
 from collections import OrderedDict
 
-from ...__helpers.model_descriptor import ImageModelDescriptor, StateDict
+from ...__helpers.model_descriptor import (
+    ImageModelDescriptor,
+    SizeRequirements,
+    StateDict,
+)
 from ..__arch_helpers.state import get_seq_len
 from .arch.RRDB import RRDBNet
 
@@ -189,4 +193,5 @@ def load(state: StateDict) -> ImageModelDescriptor[RRDBNet]:
         scale=scale,
         input_channels=in_nc,
         output_channels=out_nc,
+        size_requirements=SizeRequirements(multiple_of=4),
     )

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -23,7 +23,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -40,7 +40,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -57,7 +57,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -74,7 +74,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -91,7 +91,7 @@
     output_channels=3,
     purpose='SR',
     scale=8,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -125,7 +125,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -142,7 +142,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -159,7 +159,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -176,7 +176,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -193,7 +193,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -23,7 +23,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -40,7 +40,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -57,7 +57,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -74,7 +74,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -91,7 +91,7 @@
     output_channels=3,
     purpose='SR',
     scale=8,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -108,7 +108,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -125,7 +125,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -142,7 +142,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -159,7 +159,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -176,7 +176,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -193,7 +193,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([


### PR DESCRIPTION
As [I explained here](https://github.com/chaiNNer-org/chaiNNer/issues/2461#issuecomment-1892862759), ESRGAN models only conform with the call API, if the output image size is a multiple of 4. The easiest way to guarantee this is by making sure the input size is a multiple of 4. 