### PR TITLE
Fuzz size requirements

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -28,6 +28,8 @@ class SizeRequirements:
     """
     The minimum size of the input image in pixels.
 
+    `minimum` is **NOT** guaranteed to be a multiple of `multiple_of`.
+
     Default/neutral value: `0`
     """
     multiple_of: int = 1

--- a/src/spandrel/architectures/ESRGAN/__init__.py
+++ b/src/spandrel/architectures/ESRGAN/__init__.py
@@ -193,5 +193,8 @@ def load(state: StateDict) -> ImageModelDescriptor[RRDBNet]:
         scale=scale,
         input_channels=in_nc,
         output_channels=out_nc,
-        size_requirements=SizeRequirements(multiple_of=4 if shuffle_factor else 1),
+        size_requirements=SizeRequirements(
+            minimum=2,
+            multiple_of=4 if shuffle_factor else 1,
+        ),
     )

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -23,7 +23,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -40,7 +40,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -57,7 +57,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -74,7 +74,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -91,7 +91,7 @@
     output_channels=3,
     purpose='SR',
     scale=8,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -108,7 +108,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -125,7 +125,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -142,7 +142,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -159,7 +159,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -176,7 +176,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -193,7 +193,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=2, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -21,6 +22,23 @@ def test_ESRGAN_load():
             a.scale == b.scale and a.shuffle_factor == b.shuffle_factor
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-NMKD-YandereNeo.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Anti-Aliasing.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_ESRGAN_community(snapshot):


### PR DESCRIPTION
Progress towards #122.

This PR adds the fuzzing method and uses it for ESRGAN. I confirmed this fuzzing would have found #121, and it even found another issue: ESRGAN does not like width/height=1.

The fuzzing itself is pretty simple. We use the model's size requirements to derive a list of valid sizes. Those sizes are then used to run the model on random input images. The output of those images is then checked to see whether (1) no errors occur and (2) the output shape is correct.

I also clarified in the documentation that `minimum` is **NOT** guaranteed to be a multiple of `multiple_of`. This is surprising, so I wonder whether we should make it a guarantee.