### PR TITLE
More guarantees for `minimum` and `multiple_of` in `SizeRequirements` (bc)

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -30,6 +30,8 @@ class SizeRequirements:
 
     `minimum` is guaranteed to be a multiple of `multiple_of` and to be >= 0.
 
+    On initialization, if `minimum` is not a multiple of `multiple_of`, it will be rounded up to the next multiple of `multiple_of`.
+
     Default/neutral value: `0`
     """
     multiple_of: int = 1

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -28,13 +28,15 @@ class SizeRequirements:
     """
     The minimum size of the input image in pixels.
 
-    `minimum` is **NOT** guaranteed to be a multiple of `multiple_of`.
+    `minimum` is guaranteed to be a multiple of `multiple_of` and to be >= 0.
 
     Default/neutral value: `0`
     """
     multiple_of: int = 1
     """
     The width and height of the image must be a multiple of this value.
+
+    `multiple_of` is guaranteed to be >= 1.
 
     Default/neutral value: `1`
     """
@@ -44,6 +46,13 @@ class SizeRequirements:
 
     Default/neutral value: `False`
     """
+
+    def __post_init__(self):
+        assert self.minimum >= 0, "minimum must be >= 0"
+        assert self.multiple_of >= 1, "multiple_of must be >= 1"
+
+        if self.minimum % self.multiple_of != 0:
+            self.minimum = (self.minimum // self.multiple_of + 1) * self.multiple_of
 
     @property
     def none(self) -> bool:
@@ -56,7 +65,7 @@ class SizeRequirements:
 
     def check(self, width: int, height: int) -> bool:
         """
-        Checks if the given width and height satisfy the size requirements.
+        Returns whether the given width and height satisfy the size requirements.
         """
         if width < self.minimum or height < self.minimum:
             return False

--- a/tests/__snapshots__/test_ESRGAN.ambr
+++ b/tests/__snapshots__/test_ESRGAN.ambr
@@ -108,7 +108,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=2, multiple_of=4, square=False),
+    size_requirements=SizeRequirements(minimum=4, multiple_of=4, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/test_size_req.py
+++ b/tests/test_size_req.py
@@ -1,0 +1,16 @@
+import pytest
+
+from spandrel import SizeRequirements
+
+
+def test_size_req_init():
+    a = SizeRequirements(minimum=1, multiple_of=2)
+    assert a.minimum == 2
+    assert a.multiple_of == 2
+
+    with pytest.raises(AssertionError):
+        SizeRequirements(minimum=-1)
+    with pytest.raises(AssertionError):
+        SizeRequirements(multiple_of=0)
+    with pytest.raises(AssertionError):
+        SizeRequirements(multiple_of=-1)


### PR DESCRIPTION
We now make more guarantees for the fields of `SizeRequirements`.

This is a breaking change, because old code might now throw an exception or unknowingly invalidate the guarantees of `SizeRequirements`.