### PR TITLE
More size requirements fuzzing

### DIFF
--- a/src/spandrel/architectures/CodeFormer/__init__.py
+++ b/src/spandrel/architectures/CodeFormer/__init__.py
@@ -52,6 +52,6 @@ def load(state_dict: StateDict) -> ImageModelDescriptor[CodeFormer]:
         scale=1,
         input_channels=in_nc,
         output_channels=out_nc,
-        size_requirements=SizeRequirements(minimum=16),
+        size_requirements=SizeRequirements(multiple_of=512, square=True),
         call_fn=lambda model, image: model(image)[0],
     )

--- a/src/spandrel/architectures/FeMaSR/__init__.py
+++ b/src/spandrel/architectures/FeMaSR/__init__.py
@@ -109,7 +109,7 @@ def load(state_dict: StateDict) -> ImageModelDescriptor[FeMaSR]:
         use_residual=use_residual,
     )
 
-    multiple_of = {2: 32, 4: 16}.get(scale_factor, 1)
+    multiple_of = {2: 32, 4: 16}.get(scale_factor, 8)
 
     return ImageModelDescriptor(
         model,

--- a/src/spandrel/architectures/SCUNet/__init__.py
+++ b/src/spandrel/architectures/SCUNet/__init__.py
@@ -45,6 +45,6 @@ def load(state_dict: StateDict) -> ImageModelDescriptor[SCUNet]:
         scale=1,
         input_channels=in_nc,
         output_channels=in_nc,
-        size_requirements=SizeRequirements(minimum=16),
+        size_requirements=SizeRequirements(minimum=40),
         tiling=ModelTiling.DISCOURAGED,
     )

--- a/tests/__snapshots__/test_CodeFormer.ambr
+++ b/tests/__snapshots__/test_CodeFormer.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='FaceSR',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=512, square=True),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/__snapshots__/test_FeMaSR.ambr
+++ b/tests/__snapshots__/test_FeMaSR.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=8, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/__snapshots__/test_SCUNet.ambr
+++ b/tests/__snapshots__/test_SCUNet.ambr
@@ -6,7 +6,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=40, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -21,7 +21,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=40, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -36,7 +36,7 @@
     output_channels=3,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=40, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([
@@ -51,7 +51,7 @@
     output_channels=1,
     purpose='Restoration',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=40, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=True,
     tags=list([

--- a/tests/test_CRAFT.py
+++ b/tests/test_CRAFT.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -36,6 +37,22 @@ def test_CRAFT_load():
             and a.window_size == b.window_size
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url_zip(
+        "https://drive.google.com/file/d/13wAmc93BPeBUBQ24zUZOuUpdBFG2aAY5/view",
+        rel_model_path="pretrained_models/CRAFT_MODEL_X2.pth",
+        name="CRAFT_MODEL_X2.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url_zip(
+        "https://drive.google.com/file/d/13wAmc93BPeBUBQ24zUZOuUpdBFG2aAY5/view",
+        rel_model_path="pretrained_models/CRAFT_MODEL_X3.pth",
+        name="CRAFT_MODEL_X3.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_CRAFT_x2(snapshot):

--- a/tests/test_CodeFormer.py
+++ b/tests/test_CodeFormer.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -23,6 +24,14 @@ def test_CodeFormer_load():
             and a.codebook_size == b.codebook_size
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth"
+    )
+    # TODO: this currently doesn't ensure that 1024x1024 is invalid
+    assert_size_requirements(file.load_model(), max_size=512)
 
 
 def test_CodeFormer(snapshot):

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -28,6 +29,18 @@ def test_Compact_load():
             and a.num_conv == b.num_conv
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesr-general-x4v3.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/2x-AniScale.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_Compact_realesr_general_x4v3(snapshot):

--- a/tests/test_DAT.py
+++ b/tests/test_DAT.py
@@ -6,6 +6,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -42,6 +43,14 @@ def test_DAT_load():
             and a.num_features == b.num_features
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1iY30DyLYjar-2DjrJtAv2chCOlw4xiOj/view",
+        name="DAT_S_x4.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_DAT_S_x4(snapshot):

--- a/tests/test_DITN.py
+++ b/tests/test_DITN.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -32,6 +33,20 @@ def test_DITN_load():
             and a.ITL_blocks == b.ITL_blocks
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/12y6WjNowBkJ982fMql_yj6zBpwPKuhV2/view?usp=drive_link",
+        name="DITN_Real_GAN_x4.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1V9KHVPvLtOTwYINaD8_nGRuc37KZurkJ/view?usp=drive_link",
+        name="DITN_Real_x4.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_DITN_Real_GAN_x4(snapshot):

--- a/tests/test_FBCNN.py
+++ b/tests/test_FBCNN.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -24,6 +25,18 @@ def test_FBCNN_load():
         lambda: FBCNN(upsample_mode="pixelshuffle"),
         condition=lambda a, b: (a.nb == b.nb and a.nc == b.nc),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_color.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_gray.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_FBCNN_color(snapshot):

--- a/tests/test_FeMaSR.py
+++ b/tests/test_FeMaSR.py
@@ -1,7 +1,13 @@
 from spandrel.architectures.FeMaSR import FeMaSR, load
 from tests.test_GFPGAN import disallowed_props
 
-from .util import ModelFile, TestImage, assert_image_inference, assert_loads_correctly
+from .util import (
+    ModelFile,
+    TestImage,
+    assert_image_inference,
+    assert_loads_correctly,
+    assert_size_requirements,
+)
 
 
 def test_FeMaSR_load():
@@ -32,6 +38,18 @@ def test_FeMaSR_load():
             and a.use_semantic_loss == b.use_semantic_loss
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_HRP_model_g.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_SRX4_model_g.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_FeMaSR_1x(snapshot):

--- a/tests/test_GRL.py
+++ b/tests/test_GRL.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -126,6 +127,18 @@ def test_GRL_load():
             # and a.anchor_window_down_factor == b.anchor_window_down_factor
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/sr_grl_tiny_c3x3.ckpt"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/sr_grl_tiny_c3x4.ckpt"
+    )
+    assert_size_requirements(file.load_model())
 
 
 # def test_GRL_dn_grl_tiny_c1(snapshot):

--- a/tests/test_HAT.py
+++ b/tests/test_HAT.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -46,6 +47,20 @@ def test_HAT_load():
             and a.mlp_ratio == b.mlp_ratio
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1Y7-3IgWfIAui9BMQIsFT9CzZXVMlx__e/view?usp=drive_link",
+        name="HAT-S_SRx2.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1pdhaO1fJq3tgSqDIbymdDiGxu4S0nqVq/view?usp=drive_link",
+        name="HAT_SRx4.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_HAT_S_2x(snapshot):

--- a/tests/test_MMRealSR.py
+++ b/tests/test_MMRealSR.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -64,6 +65,18 @@ def test_MMRealSR_load():
             and a.num_block == b.num_block
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/TencentARC/MM-RealSR/releases/download/v1.0.0/MMRealSRGAN.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/TencentARC/MM-RealSR/releases/download/v1.0.0/MMRealSRNet.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_MMRealSRGAN(snapshot):

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -30,6 +31,20 @@ def test_OmniSR_load():
             and a.window_size == b.window_size
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url_zip(
+        "https://drive.google.com/file/d/17rJXJHBYt4Su8cMDMh-NOWMBdE6ki5em/view",
+        rel_model_path="OmniSR_X4_DF2K/checkpoints/epoch994_OmniSR.pth",
+        name="epoch994_OmniSR_x4.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/Phhofm/models/raw/main/2xHFA2kAVCOmniSR/2xHFA2kAVCOmniSR.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_OmniSR_official_x4(snapshot):

--- a/tests/test_RealCUGAN.py
+++ b/tests/test_RealCUGAN.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -23,6 +24,26 @@ def test_RealCUGAN_load():
         lambda: UpCunet4x(pro=True),
         condition=lambda a, b: (a.is_pro == b.is_pro),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1VtBY4ZEebEiYL-IZRGJ61LUDCSRvkdoC/view?usp=sharing",
+        name="up2x-latest-no-denoise.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1DfB-tMUKU_3NwQuM9Z0ZGYPhfLmzkDHb/view?usp=sharing",
+        name="up3x-latest-no-denoise.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1Y7SGNuivVjPf1g6F3IMvTsqt64p_pTeH/view?usp=sharing",
+        name="up4x-latest-no-denoise.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_RealCUGAN_2x(snapshot):

--- a/tests/test_SCUNet.py
+++ b/tests/test_SCUNet.py
@@ -1,6 +1,11 @@
 from spandrel.architectures.SCUNet import SCUNet, load
 
-from .util import ModelFile, assert_loads_correctly, disallowed_props
+from .util import (
+    ModelFile,
+    assert_loads_correctly,
+    assert_size_requirements,
+    disallowed_props,
+)
 
 
 def test_SCUNet_load():
@@ -14,6 +19,18 @@ def test_SCUNet_load():
         lambda: SCUNet(config=[5, 3, 7, 2, 3, 1, 3]),
         condition=lambda a, b: a.dim == b.dim and a.config == b.config,
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_gan.pth"
+    )
+    assert_size_requirements(file.load_model(), max_size=128)
+
+    file = ModelFile.from_url(
+        "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_psnr.pth"
+    )
+    assert_size_requirements(file.load_model(), max_size=128)
 
 
 def test_SCUNet_color_GAN(snapshot):

--- a/tests/test_SRFormer.py
+++ b/tests/test_SRFormer.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -48,6 +49,20 @@ def test_SRFormer_load():
             and a.patches_resolution == b.patches_resolution
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1lU8SsKeaTwBSC5bP69LjBuJs69Qt4Rsf/view?usp=drive_link",
+        name="SRFormer_SRx2_DF2K.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://drive.google.com/file/d/1Eeei_NEjDeni7ysSejmR7AwyG24fO5bp/view?usp=drive_link",
+        name="SRFormerLight_SRx3_DIV2K.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_SRFormer_SRx2_DF2K(snapshot):

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -20,6 +21,20 @@ def test_SwiftSRGAN_load():
         lambda: SwiftSRGAN(upscale_factor=4),
         lambda: SwiftSRGAN(upscale_factor=8),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_2x.pth.tar",
+        name="swift_srgan_2x.pth",
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/Koushik0901/Swift-SRGAN/releases/download/v0.1/swift_srgan_4x.pth.tar",
+        name="swift_srgan_4x.pth",
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_SwiftSRGAN_2x(snapshot):

--- a/tests/test_Swin2SR.py
+++ b/tests/test_Swin2SR.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -45,6 +46,18 @@ def test_Swin2SR_load():
             and a.patches_resolution == b.patches_resolution
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/mv-lab/swin2sr/releases/download/v0.0.1/Swin2SR_ClassicalSR_X4_64.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/mv-lab/swin2sr/releases/download/v0.0.1/Swin2SR_Jpeg_dynamic.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_Swin2SR_2x(snapshot):

--- a/tests/test_SwinIR.py
+++ b/tests/test_SwinIR.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_size_requirements,
     disallowed_props,
 )
 
@@ -29,6 +30,18 @@ def test_SwinIR_load():
             and a.patches_resolution == b.patches_resolution
         ),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/001_classicalSR_DF2K_s64w8_SwinIR-M_x2.pth"
+    )
+    assert_size_requirements(file.load_model())
+
+    file = ModelFile.from_url(
+        "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/002_lightweightSR_DIV2K_s64w8_SwinIR-S_x2.pth"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_SwinIR_M_s64w8_2x(snapshot):


### PR DESCRIPTION
Changes:
- Added size req fuzzing for a lot of archs.
- Fixed SCUNet, CodeFormer, and FeMaSR.

SCUNet is weird. The *actual* minimum size I experimentally determined is 34, but that number seems to depend on the configuration (somehow). So I just set it 40 and called it a day. Should be good enough.

CodeFormer is a bit of a problem. CodeFormer requires images to be exactly 512x512. Nothing else works. Given that we don't have a maximum size, we currently cannot express this requirement. So I just made it a multiple of 512 and square. 

I wonder whether it's worth to add a maximum size bound. I'm not sure what the default should be, though.