### PR TITLE
Clamp output tensor to guarantee output range

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -310,7 +310,7 @@ class ImageModelDescriptor(ModelBase[T], Generic[T]):
         assert isinstance(
             output, Tensor
         ), f"Expected {type(self.model).__name__} model to returns a tensor, but got {type(output)}"
-        return output
+        return output.clamp_(0, 1)
 
 
 class MaskedImageModelDescriptor(ModelBase[T], Generic[T]):
@@ -372,7 +372,7 @@ class MaskedImageModelDescriptor(ModelBase[T], Generic[T]):
         assert isinstance(
             output, Tensor
         ), f"Expected {type(self.model).__name__} model to returns a tensor, but got {type(output)}"
-        return output
+        return output.clamp_(0, 1)
 
 
 ModelDescriptor = Union[


### PR DESCRIPTION
Fixes #125.

This clamps the output tensor of the call API to guarantee an output range of 0-1. The documentation already said that the output range is 0-1, so this PR just fixes the issue that some models did not follow this.

As I pointed out in #125, this fix doesn't have a performance impact. For correctness, users of the call API had to clamp the output tensor for correctness anyway. This fix just shifts the burden of who does the clamp to the call API.