### PR TITLE
Improved error message for failed size fuzzing

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -345,6 +345,7 @@ def assert_size_requirements(
         current += req.multiple_of
 
     # fast path for non-square models
+    failed_non_square = None
     if not req.square:
         # test 2 candidates at once by using one as width and the other as height
 
@@ -356,9 +357,9 @@ def assert_size_requirements(
             for i in range(0, len(candidates), 2):
                 test_size(candidates[i], candidates[i + 1])
             return
-        except:  # noqa: E722
+        except Exception as e:  # noqa: E722
             # fall through and let the below code handle it
-            pass
+            failed_non_square = e
 
     valid: list[int] = []
     invalid: list[tuple[int, Exception]] = []
@@ -375,3 +376,8 @@ def assert_size_requirements(
             f"Valid sizes: {valid}\n"
             f"Invalid sizes: {[size for size, _ in invalid]}"
         ) from invalid[0][1]
+
+    if failed_non_square is not None:
+        raise AssertionError(
+            "Failed size requirement test for non-square models"
+        ) from failed_non_square

--- a/tests/util.py
+++ b/tests/util.py
@@ -344,16 +344,34 @@ def assert_size_requirements(
             candidates.append(current)
         current += req.multiple_of
 
-    if req.square:
-        # just test the candidates
-        for width in candidates:
-            test_size(width, width)
-    else:
+    # fast path for non-square models
+    if not req.square:
         # test 2 candidates at once by using one as width and the other as height
 
-        # make sure the list is even
-        if len(candidates) % 2 == 1:
-            candidates.append(candidates[-1])
+        try:
+            # make sure the list is even
+            if len(candidates) % 2 == 1:
+                candidates.append(candidates[-1])
 
-        for i in range(0, len(candidates), 2):
-            test_size(candidates[i], candidates[i + 1])
+            for i in range(0, len(candidates), 2):
+                test_size(candidates[i], candidates[i + 1])
+            return
+        except:  # noqa: E722
+            # fall through and let the below code handle it
+            pass
+
+    valid: list[int] = []
+    invalid: list[tuple[int, Exception]] = []
+    for width in candidates:
+        try:
+            test_size(width, width)
+            valid.append(width)
+        except Exception as e:
+            invalid.append((width, e))
+
+    if len(invalid) > 0:
+        raise AssertionError(
+            f"Failed size requirement test.\n"
+            f"Valid sizes: {valid}\n"
+            f"Invalid sizes: {[size for size, _ in invalid]}"
+        ) from invalid[0][1]


### PR DESCRIPTION
Instead of telling you the first size that fails, it will now go through all sizes and tell you which ones failed and which ones were valid. 

This makes it easy to use the fuzz test as a way to figure out the size requirements of a model. E.g. in #130, I just ran the fuzz test with default size req (so none at all), and it told me that all sizes failed except for 8. So I required multiples of 8, and then the fuzzing said everything is valid.
Basically, I used the fuzz test to automatically determine the size requirements.