### PR TITLE
Add `dtype`, `cpu`, and `cuda` to model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ model = ModelLoader().load_from_file(r"path/to/model.pth")
 assert isinstance(model, ImageModelDescriptor)
 
 # send it to the GPU and put it in inference mode
-model.to("cuda:0")
-model.eval()
+model.cuda().eval()
 
 # use the model
 def process(image: torch.Tensor) -> torch.Tensor:

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -222,6 +222,16 @@ class ModelBase(ABC, Generic[T]):
         # https://stackoverflow.com/questions/58926054/how-to-get-the-device-type-of-a-pytorch-module-conveniently
         return next(self.model.parameters()).device
 
+    @property
+    def dtype(self) -> torch.dtype:
+        """
+        The data type of the underlying module.
+
+        Use `to` to cast the model to a different data type.
+        """
+        # this makes the same assumptions as `device`
+        return next(self.model.parameters()).dtype
+
     def to(self, device: str | torch.device):
         """
         Moves the parameters and buffers of the underlying module to the given device.
@@ -229,6 +239,24 @@ class ModelBase(ABC, Generic[T]):
         Use `device` to get the current device of the model.
         """
         self.model.to(device)
+        return self
+
+    def cpu(self) -> ModelBase[T]:
+        """
+        Moves the parameters and buffers of the underlying module to the CPU.
+
+        Same as `self.to(torch.device("cpu"))`.
+        """
+        self.model.cpu()
+        return self
+
+    def cuda(self, device: int | None = None) -> ModelBase[T]:
+        """
+        Moves the parameters and buffers of the underlying module to the GPU.
+
+        Same as `self.to(torch.device("cuda"))`.
+        """
+        self.model.cuda(device)
         return self
 
     def eval(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -110,7 +110,7 @@ class ModelFile:
         return file
 
 
-disallowed_props = props("model", "state_dict", "device")
+disallowed_props = props("model", "state_dict", "device", "dtype")
 
 
 @contextmanager


### PR DESCRIPTION
This adds the `cpu` and `cuda` methods to make it easier to move the model to a different device. I also added a `dtype` property to make it easier to convert tensors to the same dtype as the model.

This is preparation for fixing `to`.