### PR TITLE
Classify spandrel as supporting 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",


### PR DESCRIPTION
We might as well say that we support py 3.12. Spandrel should support 3.12 just fine, it's just that we currently can't easily test this.

Related: #10