### PR TITLE
Pad images to size requirements in call API

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -81,6 +81,27 @@ class SizeRequirements:
 
         return True
 
+    def get_padding(self, width: int, height: int) -> tuple[int, int]:
+        """
+        Given an image size, this returns the minimum amount of padding necessary to satisfy the size requirements. The returned padding is in the format `(pad_width, pad_height)` and is guaranteed to be non-negative.
+        """
+
+        def ceil_modulo(x: int, mod: int) -> int:
+            if x % mod == 0:
+                return x
+            return (x // mod + 1) * mod
+
+        w: int = max(self.minimum, width)
+        h: int = max(self.minimum, height)
+
+        w = ceil_modulo(w, self.multiple_of)
+        h = ceil_modulo(h, self.multiple_of)
+
+        if self.square:
+            w = h = max(w, h)
+
+        return w - width, h - height
+
 
 Purpose = Literal["SR", "FaceSR", "Inpainting", "Restoration"]
 """

--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -224,6 +224,8 @@ class ModelBase(ABC, Generic[T]):
         Size requirements for the input image. E.g. minimum size.
 
         Requirements are specific to individual models and may be different for models of the same architecture.
+
+        Users of spandrel's call API can largely ignore size requirements, because the call API will automatically pad the input image to satisfy the requirements. Size requirements might still be useful for user code that tiles images by allowing it to pick an optimal tile size to avoid padding.
         """
         self.tiling: ModelTiling = tiling
         """


### PR DESCRIPTION
Changes:
- Add `get_padding` for `SizeRequirements`. This method will return the necessary to make a size satisfy the requirements.
- Automatically pad (and later unpad) input images in the call API. This means that user code no longer has to handle padding and can run models on images of any size.
- Some additional checks to verify call API requirements.