### PR TITLE
Fix Google Drive downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,27 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
-dependencies = ["torch", "torchvision", "safetensors", "numpy", "einops", "typing_extensions"]
+dependencies = [
+    "torch",
+    "torchvision",
+    "safetensors",
+    "numpy",
+    "einops",
+    "typing_extensions",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 build = ["build", "twine"]
 lint = ["ruff==0.1.11"]
 typecheck = ["pyright==1.1.342"]
-test = ["pytest==7.4.0", "syrupy==4.6.0", "opencv-python==4.8.1.78"]
+test = [
+    "pytest==7.4.0",
+    "syrupy==4.6.0",
+    "opencv-python==4.8.1.78",
+    "requests",
+    "beautifulsoup4",
+]
 docs = ["pydoctor==23.9.1"]
 
 [tool.setuptools]


### PR DESCRIPTION
The `confirm=1` trick to get direct downloads even for large files recently (like a week ago) stopped working. So instead of downloading the file, Google Drive will give us a warning page "File too large to scan for viruses. Download Anyway?". So our automatic model downloading for tests will download those warning pages instead of models.

Luckily, this warning page is **very** simple. No JS. Just simple HTML forms. So I just parse the form and piece together the real download link. This seems to work without problems.

*Why hasn't this been a problem in recent PRs?* Since our CI uses a cache, we weren't affected by this problem right away. The next time the cache gets evicted, we would be in trouble though because most Google Drive downloads will fail.