### PR TITLE
Add FOSS build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,11 @@ jobs:
         run: |
           python -m build . --wheel
           twine upload --repository pypi dist/*
+      - name: Build and publish (FOSS)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python ./scripts/prepare_foss_version.py
+          python -m build . --wheel
+          twine upload --repository pypi dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "spandrel"
 authors = [{ name = "chaiNNer team" }]
-description = "Give your project support for a variety of PyTorch model architectures, including auto-detecting model architecture from just .pth files. spandrel gives you arch support."
+description = "Give your project support for a variety of PyTorch model architectures, including auto-detecting model architecture from just .pth files."
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = [

--- a/scripts/prepare_foss_version.py
+++ b/scripts/prepare_foss_version.py
@@ -1,0 +1,64 @@
+"""
+    This script removes non-FOSS compliant code from the architectures directory and modifies the repo to be able to publish a different package.
+"""
+
+import shutil
+
+import toml
+
+archs_to_remove = ["CodeFormer", "DDColor", "FeMaSR", "GFPGAN", "MAT", "SRFormer"]
+
+# Remove non-FOSS compliant code
+for arch in archs_to_remove:
+    shutil.rmtree(f"src/spandrel/architectures/{arch}", ignore_errors=True)
+
+# Change pyproject.toml info
+
+# Read in the file
+with open("pyproject.toml") as file:
+    data = toml.load(file)
+
+note_string = "This version of Spandrel is FOSS compliant as it remove support for model architectures that are under a non-commercial license."
+
+# Change the package name
+data["project"]["name"] = "spandrel-foss"
+data["project"]["description"] = f'{data["project"]["description"]} {note_string}'
+
+# Write the file out again
+with open("pyproject.toml", "w") as file:
+    toml.dump(data, file)
+
+
+# Update the readme
+with open("README.md") as file:
+    readme = file.read()
+
+readme_split = readme.split("\n")
+readme = "\n".join([readme_split[0]] + [note_string] + readme_split[1:])
+
+with open("README.md", "w") as file:
+    file.write(readme)
+
+
+# Update the registry
+with open("src/spandrel/__helpers/main_registry.py") as file:
+    registry = file.read()
+
+for arch in archs_to_remove:
+    registry = registry.replace(f"    {arch},\n", "")
+    registry_split = registry.split("\n")
+    registry_out = registry_split
+    for i, line in enumerate(registry_split):
+        if f'id="{arch}"' in line:
+            while "ArchSupport" not in registry_split[i]:
+                registry_out[i] = ""
+                i -= 1
+            registry_out[i] = ""
+            i += 1
+            while "ArchSupport" not in registry_split[i]:
+                registry_out[i] = ""
+                i += 1
+    registry = "\n".join(registry_out)
+
+with open("src/spandrel/__helpers/main_registry.py", "w") as file:
+    file.write(registry)


### PR DESCRIPTION
After talking with comfyanonymous, it is clear we need a separate version of Spandrel that only contains model archs with FOSS-compliant (aka support commercial software) licenses. 

This is a bit of a dirty way of doing it, but I figured a temporary solution would be good for now until we figure out a better way.

Basically, I just wrote a script to delete the arch files and modify the arch registry to remove support for the few model archs that are not FOSS-compliant.

The script also modifies the README to note this, as well as changes the package name. 

I have already published a wheel made using this script, which can be found [here](https://pypi.org/project/spandrel-foss/0.2.2/)

Once everything is confirmed to be good, I will update my [comfyui PR](https://github.com/comfyanonymous/ComfyUI/pull/2146) with this version of the package.