### PR TITLE
Make it possible to save SPAN models as `.safetensors`

### DIFF
--- a/src/spandrel/architectures/SPAN/arch/span.py
+++ b/src/spandrel/architectures/SPAN/arch/span.py
@@ -182,8 +182,8 @@ class Conv3XC(nn.Module):
         self.weight_concat = self.weight_concat + sk_w
         self.bias_concat = self.bias_concat + sk_b
 
-        self.eval_conv.weight.data = self.weight_concat
-        self.eval_conv.bias.data = self.bias_concat  # type: ignore
+        self.eval_conv.weight.data = self.weight_concat.contiguous()
+        self.eval_conv.bias.data = self.bias_concat.contiguous()  # type: ignore
 
     def forward(self, x):
         if self.training:


### PR DESCRIPTION
Calling `.contiguous()` for the tensors we assign as weight and bias makes safetensors happy.