### PR TITLE
Add tests for saving models as and loading from `.safetensors` files

### DIFF
--- a/src/spandrel/architectures/SCUNet/arch/SCUNet.py
+++ b/src/spandrel/architectures/SCUNet/arch/SCUNet.py
@@ -48,6 +48,7 @@ class WMSA(nn.Module):
             )
             .transpose(1, 2)
             .transpose(0, 1)
+            .contiguous()
         )
 
     def generate_mask(self, h, w, p, shift):

--- a/tests/test_GFPGAN.py
+++ b/tests/test_GFPGAN.py
@@ -1,4 +1,5 @@
-from spandrel.architectures.GFPGAN import GFPGANv1Clean
+from spandrel.architectures.GFPGAN import GFPGANArch, GFPGANv1Clean
+from tests.test_CodeFormer import assert_loads_correctly
 
 from .util import (
     ModelFile,
@@ -6,6 +7,13 @@ from .util import (
     assert_image_inference,
     disallowed_props,
 )
+
+
+def test_load():
+    assert_loads_correctly(
+        GFPGANArch(),
+        lambda: GFPGANv1Clean(),
+    )
 
 
 def test_GFPGAN_1_2(snapshot):

--- a/tests/test_SCUNet.py
+++ b/tests/test_SCUNet.py
@@ -18,6 +18,7 @@ def test_SCUNet_load():
         lambda: SCUNet(dim=24),
         lambda: SCUNet(config=[5, 3, 7, 2, 3, 1, 3]),
         condition=lambda a, b: a.dim == b.dim and a.config == b.config,
+        check_safe_tensors=False,
     )
 
 

--- a/tests/test_SPSR.py
+++ b/tests/test_SPSR.py
@@ -89,4 +89,5 @@ def test_SPSR_load():
             upscale=8,
             upsample_mode="pixelshuffle",
         ),
+        check_safe_tensors=False,
     )


### PR DESCRIPTION
Fixes #158.

I added the `.safetensors` test into `assert_loads_correctly`, because it was easy and because it means that we'll test many parameter configurations.