### PR TITLE
Rename all `test_ARCHNAME_load` functions to `test_load`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ from spandrel.architectures.ARCH_NAME import ARCH_NAME, load
 from .util import assert_loads_correctly
 
 
-def test_ARCH_NAME_load():
+def test_load():
     assert_loads_correctly(
         load,
         lambda: ARCH_NAME(),
@@ -295,7 +295,7 @@ from spandrel.architectures.DITN import DITN, load
 from .util import assert_loads_correctly
 
 
-def test_DITN_load():
+def test_load():
     assert_loads_correctly(
         load,
         lambda: DITN(),
@@ -607,7 +607,7 @@ from .util import (
 )
 
 
-def test_ARCH_load():
+def test_load():
     ...
 
 

--- a/tests/test_CRAFT.py
+++ b/tests/test_CRAFT.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_CRAFT_load():
+def test_load():
     assert_loads_correctly(
         CRAFTArch(),
         lambda: CRAFT(),

--- a/tests/test_CodeFormer.py
+++ b/tests/test_CodeFormer.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_CodeFormer_load():
+def test_load():
     assert_loads_correctly(
         CodeFormerArch(),
         lambda: CodeFormer(),

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_Compact_load():
+def test_load():
     assert_loads_correctly(
         CompactArch(),
         lambda: SRVGGNetCompact(),

--- a/tests/test_DAT.py
+++ b/tests/test_DAT.py
@@ -11,7 +11,7 @@ from .util import (
 )
 
 
-def test_DAT_load():
+def test_load():
     assert_loads_correctly(
         DATArch(),
         lambda: DAT(),

--- a/tests/test_DDColor.py
+++ b/tests/test_DDColor.py
@@ -9,7 +9,7 @@ from .util import (
 )
 
 
-def test_DDColor_load():
+def test_load():
     assert_loads_correctly(
         DDColorArch(),
         lambda: DDColor(

--- a/tests/test_DITN.py
+++ b/tests/test_DITN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_DITN_load():
+def test_load():
     assert_loads_correctly(
         DITNArch(),
         lambda: DITN(),

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_ESRGAN_load():
+def test_load():
     assert_loads_correctly(
         ESRGANArch(),
         lambda: RRDBNet(in_nc=3, out_nc=3, num_filters=64, num_blocks=23, scale=4),

--- a/tests/test_FBCNN.py
+++ b/tests/test_FBCNN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_FBCNN_load():
+def test_load():
     assert_loads_correctly(
         FBCNNArch(),
         lambda: FBCNN(),

--- a/tests/test_FeMaSR.py
+++ b/tests/test_FeMaSR.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_FeMaSR_load():
+def test_load():
     assert_loads_correctly(
         FeMaSRArch(),
         lambda: FeMaSR(),

--- a/tests/test_GRL.py
+++ b/tests/test_GRL.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_GRL_load():
+def test_load():
     assert_loads_correctly(
         GRLArch(),
         lambda: GRL(),

--- a/tests/test_HAT.py
+++ b/tests/test_HAT.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_HAT_load():
+def test_load():
     assert_loads_correctly(
         HATArch(),
         lambda: HAT(),

--- a/tests/test_KBNet.py
+++ b/tests/test_KBNet.py
@@ -3,7 +3,7 @@ from spandrel.architectures.KBNet import KBNet_l, KBNet_s, KBNetArch
 from .util import assert_loads_correctly
 
 
-def test_KBCNN_load():
+def test_load():
     assert_loads_correctly(
         KBNetArch(),
         lambda: KBNet_l(),

--- a/tests/test_LaMa.py
+++ b/tests/test_LaMa.py
@@ -3,7 +3,7 @@ from spandrel.architectures.LaMa import LaMa, LaMaArch
 from .util import ModelFile, assert_loads_correctly, disallowed_props
 
 
-def test_LaMa_load():
+def test_load():
     assert_loads_correctly(
         LaMaArch(),
         lambda: LaMa(),

--- a/tests/test_MMRealSR.py
+++ b/tests/test_MMRealSR.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_MMRealSR_load():
+def test_load():
     assert_loads_correctly(
         MMRealSRArch(),
         # num_block=2 is used everywhere to make tests faster

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_OmniSR_load():
+def test_load():
     assert_loads_correctly(
         OmniSRArch(),
         lambda: OmniSR(),

--- a/tests/test_RealCUGAN.py
+++ b/tests/test_RealCUGAN.py
@@ -15,7 +15,7 @@ from .util import (
 )
 
 
-def test_RealCUGAN_load():
+def test_load():
     assert_loads_correctly(
         RealCUGANArch(),
         lambda: UpCunet2x(in_channels=3, out_channels=3),

--- a/tests/test_RestoreFormer.py
+++ b/tests/test_RestoreFormer.py
@@ -3,7 +3,7 @@ from spandrel.architectures.RestoreFormer import RestoreFormer, RestoreFormerArc
 from .util import ModelFile, assert_loads_correctly, disallowed_props
 
 
-def test_RestoreFormer_load():
+def test_load():
     assert_loads_correctly(
         RestoreFormerArch(),
         lambda: RestoreFormer(),

--- a/tests/test_SAFMN.py
+++ b/tests/test_SAFMN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_SAFMN_load():
+def test_load():
     assert_loads_correctly(
         SAFMNArch(),
         lambda: SAFMN(dim=36, n_blocks=8, ffn_scale=2.0, upscaling_factor=4),

--- a/tests/test_SCUNet.py
+++ b/tests/test_SCUNet.py
@@ -8,7 +8,7 @@ from .util import (
 )
 
 
-def test_SCUNet_load():
+def test_load():
     assert_loads_correctly(
         SCUNetArch(),
         lambda: SCUNet(),

--- a/tests/test_SPAN.py
+++ b/tests/test_SPAN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_SPAN_load():
+def test_load():
     assert_loads_correctly(
         SPANArch(),
         lambda: SPAN(num_in_ch=3, num_out_ch=3),

--- a/tests/test_SPSR.py
+++ b/tests/test_SPSR.py
@@ -3,7 +3,7 @@ from spandrel.architectures.SPSR import SPSR, SPSRArch
 from .util import assert_loads_correctly
 
 
-def test_SPSR_load():
+def test_load():
     assert_loads_correctly(
         SPSRArch(),
         lambda: SPSR(

--- a/tests/test_SRFormer.py
+++ b/tests/test_SRFormer.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_SRFormer_load():
+def test_load():
     assert_loads_correctly(
         SRFormerArch(),
         lambda: SRFormer(window_size=8),

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_SwiftSRGAN_load():
+def test_load():
     assert_loads_correctly(
         SwiftSRGANArch(),
         lambda: SwiftSRGAN(),

--- a/tests/test_Swin2SR.py
+++ b/tests/test_Swin2SR.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_Swin2SR_load():
+def test_load():
     assert_loads_correctly(
         Swin2SRArch(),
         lambda: Swin2SR(window_size=8, upsampler="pixelshuffledirect"),

--- a/tests/test_SwinIR.py
+++ b/tests/test_SwinIR.py
@@ -10,7 +10,7 @@ from .util import (
 )
 
 
-def test_SwinIR_load():
+def test_load():
     assert_loads_correctly(
         SwinIRArch(),
         lambda: SwinIR(window_size=8),

--- a/tests/test_Uformer.py
+++ b/tests/test_Uformer.py
@@ -3,7 +3,7 @@ from spandrel.architectures.Uformer import Uformer, UformerArch
 from .util import assert_loads_correctly
 
 
-def test_Uformer_load():
+def test_load():
     assert_loads_correctly(
         UformerArch(),
         lambda: Uformer(),


### PR DESCRIPTION
I just think it's cleaner, and it was always a little annoying to add the arch name to every test function.