### PR TITLE
Optimize for inference when using call api

### DIFF
--- a/src/spandrel/__helpers/model_descriptor.py
+++ b/src/spandrel/__helpers/model_descriptor.py
@@ -468,13 +468,10 @@ class ImageModelDescriptor(ModelBase[T], Generic[T]):
         did_pad, image = pad_tensor(image, self.size_requirements)
 
         # Optimize for inference
-        for _, v in self.model.named_parameters():
-            v.requires_grad = False
         self.model.eval()
 
         # call model
-        with torch.no_grad():
-            output = self._call_fn(self.model, image)
+        output = self._call_fn(self.model, image)
         assert isinstance(
             output, Tensor
         ), f"Expected {type(self.model).__name__} model to return a tensor, but got {type(output)}"


### PR DESCRIPTION
Generally speaking, it's always good to put a model in inference mode when performing inference. I figure it's probably good to do this automatically when using the call api to prevent possible problems.

Could theoretically be related to #160 but I think they are doing the right things there so I don't think tat's it