### PR TITLE
Polish util API

### DIFF
--- a/src/spandrel/util.py
+++ b/src/spandrel/util.py
@@ -5,7 +5,7 @@ A module containing commonly-used functionality to implement architectures.
 from __future__ import annotations
 
 import math
-from typing import Any, Literal
+from typing import Literal, Mapping
 
 
 class KeyCondition:
@@ -27,7 +27,7 @@ class KeyCondition:
     def has_any(*keys: str | KeyCondition) -> KeyCondition:
         return KeyCondition("any", keys)
 
-    def __call__(self, state_dict: dict[str, Any]) -> bool:
+    def __call__(self, state_dict: Mapping[str, object]) -> bool:
         def _detect(key: str | KeyCondition) -> bool:
             if isinstance(key, KeyCondition):
                 return key(state_dict)
@@ -39,7 +39,7 @@ class KeyCondition:
             return any(_detect(key) for key in self._keys)
 
 
-def get_first_seq_index(state: dict, key_pattern: str) -> int:
+def get_first_seq_index(state_dict: Mapping[str, object], key_pattern: str) -> int:
     """
     Returns the maximum index `i` such that `key_pattern.format(str(i))` is in `state`.
 
@@ -50,12 +50,12 @@ def get_first_seq_index(state: dict, key_pattern: str) -> int:
         get_first_seq_index(state, "body.{}.weight") -> 3
     """
     for i in range(100):
-        if key_pattern.format(str(i)) in state:
+        if key_pattern.format(str(i)) in state_dict:
             return i
     return -1
 
 
-def get_seq_len(state: dict[str, Any], seq_key: str) -> int:
+def get_seq_len(state_dict: Mapping[str, object], seq_key: str) -> int:
     """
     Returns the length of a sequence in the state dict.
 
@@ -68,7 +68,7 @@ def get_seq_len(state: dict[str, Any], seq_key: str) -> int:
     prefix = seq_key + "."
 
     keys: set[int] = set()
-    for k in state.keys():
+    for k in state_dict.keys():
         if k.startswith(prefix):
             index = k[len(prefix) :].split(".", maxsplit=1)[0]
             keys.add(int(index))


### PR DESCRIPTION
Changes: 
- Consistently use the argument name `state_dict`.
- Use `Mapping[str, object]` as the type for the `state_dict` arguments. This type guarantees that we don't modify the dict we get.