### PR TITLE
Excluded package READMEs from triggering test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
             - closed
         paths:
             - 'libs/**'
+            - '!libs/**/*.md'
             - 'tests/**'
             - '.github/workflows/**'
             - 'pyproject.toml'


### PR DESCRIPTION
README edits shouldn't trigger the tests to run.