### PR TITLE
Specify required spandrel version

### DIFF
--- a/libs/spandrel_extra_arches/pyproject.toml
+++ b/libs/spandrel_extra_arches/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "spandrel~=0.3.0",
+    "spandrel>=0.3.0",
     "torch",
     "torchvision",
     "numpy",

--- a/libs/spandrel_extra_arches/pyproject.toml
+++ b/libs/spandrel_extra_arches/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "spandrel",
+    "spandrel~=0.3.0",
     "torch",
     "torchvision",
     "numpy",


### PR DESCRIPTION
This PR specifies that `spandrel_extra_arches` needs at least spandrel v0.3.0 to function.