### PR TITLE
Support APISR models

### DIFF
--- a/libs/spandrel/spandrel/__helpers/canonicalize.py
+++ b/libs/spandrel/spandrel/__helpers/canonicalize.py
@@ -22,7 +22,15 @@ def canonicalize_state_dict(state_dict: StateDict) -> StateDict:
     """
 
     # the real state dict might be inside a dict with a known key
-    unwrap_keys = ["state_dict", "params_ema", "params-ema", "params", "model", "net"]
+    unwrap_keys = [
+        "model_state_dict",
+        "state_dict",
+        "params_ema",
+        "params-ema",
+        "params",
+        "model",
+        "net",
+    ]
     for unwrap_key in unwrap_keys:
         if unwrap_key in state_dict and isinstance(state_dict[unwrap_key], dict):
             state_dict = state_dict[unwrap_key]


### PR DESCRIPTION
Instead of the usual suspects, APISR uses "model_state_dict" as the key under which to store weights. While I don't think that we should support every possible key, "model_state_dict" is pretty much in line with the other keys, so I think it's fine to support this one.

Closes #199