### PR TITLE
Always unwrap single-key state dicts

### DIFF
--- a/libs/spandrel/spandrel/__helpers/canonicalize.py
+++ b/libs/spandrel/spandrel/__helpers/canonicalize.py
@@ -36,6 +36,12 @@ def canonicalize_state_dict(state_dict: StateDict) -> StateDict:
             state_dict = state_dict[unwrap_key]
             break
 
+    # unwrap single key
+    if len(state_dict) == 1:
+        single = next(iter(state_dict.values()))
+        if isinstance(single, dict):
+            state_dict = single
+
     # remove known common prefixes
     state_dict = remove_common_prefix(state_dict, ["module.", "netG."])
 


### PR DESCRIPTION
This implements Joey's idea:

> To potentially support more things that do that, could we check if the top level keys length is 1, and if that key contains a dict? If so, then unwrap it, regardless of what it is