### PR TITLE
Improve loading utility error messages using expected arch

### DIFF
--- a/libs/spandrel/spandrel/util/__init__.py
+++ b/libs/spandrel/spandrel/util/__init__.py
@@ -19,7 +19,7 @@ class KeyCondition:
         self, kind: Literal["all", "any"], keys: tuple[str | KeyCondition, ...]
     ):
         self._keys = keys
-        self._kind = kind
+        self._kind: Literal["all", "any"] = kind
 
     @staticmethod
     def has_all(*keys: str | KeyCondition) -> KeyCondition:


### PR DESCRIPTION
This adds an optional parameter to `ModelFile.load_model` to specify the expected architecture of the loaded model. This is useful, because it allows `load_model` to give better errors messages. E.g. it will say that the given arch in the registry (because I sometimes forget to add them), and it will list all keys that are required by the key condition but not in the model (making it easier to debug key conditions).