### PR TITLE
Don't exit on invalid parameters

### DIFF
--- a/libs/spandrel/spandrel/architectures/CRAFT/arch/CRAFT.py
+++ b/libs/spandrel/spandrel/architectures/CRAFT/arch/CRAFT.py
@@ -141,8 +141,7 @@ class Attention_regular(nn.Module):
         elif idx == 1:
             W_sp, H_sp = self.split_size[0], self.split_size[1]
         else:
-            print("ERROR MODE", idx)
-            exit(0)
+            raise ValueError(f"ERROR MODE: {idx}")
         self.H_sp = H_sp
         self.W_sp = W_sp
 

--- a/libs/spandrel/spandrel/architectures/DAT/arch/DAT.py
+++ b/libs/spandrel/spandrel/architectures/DAT/arch/DAT.py
@@ -195,8 +195,7 @@ class Spatial_Attention(nn.Module):
         elif idx == 1:
             W_sp, H_sp = self.split_size[0], self.split_size[1]
         else:
-            print("ERROR MODE", idx)
-            exit(0)
+            raise ValueError(f"ERROR MODE: {idx}")
         self.H_sp = H_sp
         self.W_sp = W_sp
 

--- a/libs/spandrel/spandrel/architectures/RGT/arch/rgt.py
+++ b/libs/spandrel/spandrel/architectures/RGT/arch/rgt.py
@@ -165,8 +165,7 @@ class WindowAttention(nn.Module):
         elif idx == 1:
             W_sp, H_sp = self.split_size[0], self.split_size[1]
         else:
-            print("ERROR MODE", idx)
-            exit(0)
+            raise ValueError(f"ERROR MODE: {idx}")
         self.H_sp = H_sp
         self.W_sp = W_sp
 


### PR DESCRIPTION
Supplying invalid parameters probably shouldn't be a cause to exit the process.