### PR TITLE
Skip DnCNN and DRUNet tests if unchanged

### DIFF
--- a/tests/test_DRUNet.py
+++ b/tests/test_DRUNet.py
@@ -7,7 +7,10 @@ from .util import (
     assert_loads_correctly,
     assert_size_requirements,
     disallowed_props,
+    skip_if_unchanged,
 )
+
+skip_if_unchanged(__file__)
 
 
 def test_load():

--- a/tests/test_DnCNN.py
+++ b/tests/test_DnCNN.py
@@ -7,7 +7,10 @@ from .util import (
     assert_loads_correctly,
     assert_size_requirements,
     disallowed_props,
+    skip_if_unchanged,
 )
+
+skip_if_unchanged(__file__)
 
 
 def test_load():


### PR DESCRIPTION
My CI changes PR came at the same time as DRUNet and DnCNN, so I forgot to add `skip_if_unchanged` to those tests.