### PR TITLE
Detect archictecture in `assert_loads_correctly`

### DIFF
--- a/libs/spandrel/spandrel/architectures/DAT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/DAT/__init__.py
@@ -18,9 +18,47 @@ class DATArch(Architecture[DAT]):
         super().__init__(
             id="DAT",
             detect=KeyCondition.has_all(
-                "layers.0.blocks.2.attn.attn_mask_0",
-                "layers.0.blocks.0.ffn.fc1.weight",
                 "conv_first.weight",
+                "before_RG.1.weight",
+                "before_RG.1.bias",
+                "layers.0.blocks.0.norm1.weight",
+                "layers.0.blocks.0.norm2.weight",
+                "layers.0.blocks.0.ffn.fc1.weight",
+                "layers.0.blocks.0.ffn.sg.norm.weight",
+                "layers.0.blocks.0.ffn.sg.conv.weight",
+                "layers.0.blocks.0.ffn.fc2.weight",
+                "layers.0.blocks.0.attn.qkv.weight",
+                "layers.0.blocks.0.attn.proj.weight",
+                "layers.0.blocks.0.attn.dwconv.0.weight",
+                "layers.0.blocks.0.attn.dwconv.1.running_mean",
+                "layers.0.blocks.0.attn.channel_interaction.1.weight",
+                "layers.0.blocks.0.attn.channel_interaction.2.running_mean",
+                "layers.0.blocks.0.attn.channel_interaction.4.weight",
+                "layers.0.blocks.0.attn.spatial_interaction.0.weight",
+                "layers.0.blocks.0.attn.spatial_interaction.1.running_mean",
+                "layers.0.blocks.0.attn.spatial_interaction.3.weight",
+                "layers.0.blocks.0.attn.attns.0.rpe_biases",
+                "layers.0.blocks.0.attn.attns.0.relative_position_index",
+                "layers.0.blocks.0.attn.attns.0.pos.pos_proj.weight",
+                "layers.0.blocks.0.attn.attns.0.pos.pos1.0.weight",
+                "layers.0.blocks.0.attn.attns.0.pos.pos3.0.weight",
+                "norm.weight",
+                KeyCondition.has_any(
+                    # resi_connection="1conv"
+                    "conv_after_body.weight",
+                    # resi_connection="3conv"
+                    "conv_after_body.4.weight",
+                ),
+                KeyCondition.has_any(
+                    # upsampler="pixelshuffle"
+                    KeyCondition.has_all(
+                        "conv_after_body.weight",
+                        "conv_before_upsample.0.weight",
+                        "conv_last.weight",
+                    ),
+                    # upsampler="pixelshuffledirect"
+                    "upsample.0.weight",
+                ),
             ),
         )
 

--- a/libs/spandrel/spandrel/architectures/HAT/arch/HAT.py
+++ b/libs/spandrel/spandrel/architectures/HAT/arch/HAT.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -918,7 +919,7 @@ class HAT(nn.Module):
         use_checkpoint=False,
         upscale=1,
         img_range=1.0,
-        upsampler="",
+        upsampler: Literal["pixelshuffle"] = "pixelshuffle",
         resi_connection="1conv",
         num_feat=64,
     ):

--- a/libs/spandrel/spandrel/architectures/RGT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/RGT/__init__.py
@@ -63,7 +63,12 @@ class RGTArch(Architecture[RGT]):
                 "layers.0.blocks.0.mlp.fc2.weight",
                 "layers.0.blocks.0.norm2.weight",
                 "norm.weight",
-                "conv_after_body.weight",
+                KeyCondition.has_any(
+                    # 1conv
+                    "conv_after_body.weight",
+                    # 3conv
+                    "conv_after_body.0.weight",
+                ),
                 "conv_before_upsample.0.weight",
                 "conv_last.weight",
             ),

--- a/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/FeMaSR/__init__.py
+++ b/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/FeMaSR/__init__.py
@@ -47,8 +47,14 @@ class FeMaSRArch(Architecture[FeMaSR]):
                 "multiscale_encoder.in_conv.weight",
                 "multiscale_encoder.blocks.0.0.weight",
                 "decoder_group.0.block.1.weight",
+                "decoder_group.0.block.2.conv.2.weight",
+                "decoder_group.0.block.2.conv.5.weight",
+                "decoder_group.0.block.3.conv.2.weight",
+                "decoder_group.0.block.3.conv.5.weight",
                 "out_conv.weight",
+                "quantize_group.0.embedding.weight",
                 "before_quant_group.0.weight",
+                "after_quant_group.0.conv.weight",
             ),
         )
 

--- a/tests/test_AdaCode.py
+++ b/tests/test_AdaCode.py
@@ -23,7 +23,7 @@ def test_load():
         lambda: AdaCode(gt_resolution=128),
         lambda: AdaCode(LQ_stage=True, scale_factor=2),
         lambda: AdaCode(LQ_stage=True, scale_factor=4),
-        lambda: AdaCode(LQ_stage=True, scale_factor=8),
+        lambda: AdaCode(LQ_stage=True, scale_factor=8, codebook_params=[[8, 32, 32]]),
         lambda: AdaCode(norm_type="gn"),
         lambda: AdaCode(norm_type="bn"),
         lambda: AdaCode(norm_type="in"),

--- a/tests/test_FeMaSR.py
+++ b/tests/test_FeMaSR.py
@@ -23,7 +23,7 @@ def test_load():
         lambda: FeMaSR(gt_resolution=128),
         lambda: FeMaSR(LQ_stage=True, scale_factor=2),
         lambda: FeMaSR(LQ_stage=True, scale_factor=4),
-        lambda: FeMaSR(LQ_stage=True, scale_factor=8),
+        lambda: FeMaSR(LQ_stage=True, scale_factor=8, codebook_params=[[8, 32, 32]]),
         lambda: FeMaSR(norm_type="gn"),
         lambda: FeMaSR(norm_type="bn"),
         lambda: FeMaSR(norm_type="in"),

--- a/tests/util.py
+++ b/tests/util.py
@@ -399,6 +399,7 @@ def assert_loads_correctly(
     *models: Callable[[], T],
     check_safe_tensors: bool = True,
     ignore_parameters: set[str] | None = None,
+    detect: bool = True,
 ):
     @runtime_checkable
     class WithHyperparameters(Protocol):
@@ -455,6 +456,9 @@ def assert_loads_correctly(
                 ) from e
 
             assert_same(model_name, model, sf_loaded.model)
+
+        if detect:
+            assert arch.detect(state_dict), f"Failed to detect: {model_name}"
 
 
 def seed_rngs(seed: int) -> None:


### PR DESCRIPTION
Since some architectures can have highly varying state dicts depending on their hyperparameters, I added an optional `detect: bool = True` argument to `assert_loads_correctly`. If enabled, `assert_loads_correctly` will check that the `detect` method of the architecture correctly identifies a model of its architecture. This means that our `detect` methods aren't just tested by example model files, but also by the diverse set of models used to test parameter detection.