### PR TITLE
Improve caches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
-                  cache: 'pip'
             - uses: pre-commit/action@v3.0.0
               env:
                 RUFF_OUTPUT_FORMAT: github
@@ -37,7 +36,6 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
-                  cache: 'pip'
             - run: sh scripts/install.sh
             - run: pyright libs/
             - run: pyright tests/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,39 +4,39 @@ name: Lint
 
 # Controls when the workflow will run
 on:
-    pull_request:
-        branches: ['*']
-        types:
-            - opened
-            - synchronize
-            - closed
-    push:
-        branches: [main]
+  pull_request:
+    branches: ["*"]
+    types:
+      - opened
+      - synchronize
+      - closed
+  push:
+    branches: [main]
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    lint:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.11'
-            - uses: pre-commit/action@v3.0.0
-              env:
-                RUFF_OUTPUT_FORMAT: github
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: pre-commit/action@v3.0.0
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
-    pyright:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.11'
-            - run: sh scripts/install.sh
-            - run: pyright libs/
-            - run: pyright tests/
-            - run: pyright scripts/
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: sh scripts/install.sh
+      - run: pyright libs/
+      - run: pyright tests/
+      - run: pyright scripts/

--- a/.github/workflows/release-spandrel.yml
+++ b/.github/workflows/release-spandrel.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install dependencies
         run: sh scripts/install.sh
       - name: Build packages
@@ -37,7 +37,7 @@ jobs:
         uses: actions/configure-pages@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - run: sh scripts/install.sh
       - name: Build the website
         run: pydoctor --project-url=https://github.com/$GITHUB_REPOSITORY --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA

--- a/.github/workflows/release-spandrel_extra_arches.yml
+++ b/.github/workflows/release-spandrel_extra_arches.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install dependencies
         run: sh scripts/install.sh
       - name: Build packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,62 +4,67 @@ name: Test
 
 # Controls when the workflow will run
 on:
-    pull_request:
-        branches: ['*']
-        types:
-            - opened
-            - synchronize
-            - closed
-        paths:
-            - 'libs/**'
-            - '!libs/**/*.md'
-            - 'tests/**'
-            - '.github/workflows/**'
-            - 'pyproject.toml'
-    push:
-        branches: [main]
+  pull_request:
+    branches: ["*"]
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "libs/**"
+      - "!libs/**/*.md"
+      - "tests/**"
+      - ".github/workflows/**"
+      - "pyproject.toml"
+  push:
+    branches: [main]
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - run: sh scripts/install.sh
-            - name: Cache models
-              id: cache-models
-              uses: actions/cache@v3
-              with:
-                  path: tests/models
-                  key: update-2023-11-29
-            - run: pytest tests
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: sh scripts/install.sh
+      - name: Cache models
+        id: cache-models
+        uses: actions/cache@v3
+        with:
+          path: tests/models
+          key: update-2023-11-29
+      - run: pytest tests
+      - name: Remove models downloaded from GitHub
+        run: |
+          touch tests/_github_files.txt
+          echo "Files removed from cache:"
+          cat tests/_github_files.txt
+          xargs rm < tests/_github_files.txt
 
-    docs:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.11'
-            - run: sh scripts/install.sh
-            - run: pydoctor
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: sh scripts/install.sh
+      - run: pydoctor
 
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.11'
-            - run: sh scripts/install.sh
-            - run: sh scripts/build.sh
-
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: sh scripts/install.sh
+      - run: sh scripts/build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: 'pip'
             - run: sh scripts/install.sh
             - name: Cache models
               id: cache-models


### PR DESCRIPTION
My current guess is that our CI fails because we cache too many models. GH only gives us 10GB, so we were almost hitting that limit previously.

This PR changes two things:
1. Don't cache pip installs. We don't really get a huge speedup for that, but we do have to pay 250MB per runner.
2. Remove model files that were downloaded from GitHub. We mainly use the cache to speed up tests, but there's no difference in download speed between GitHub CI downloading a model from cache vs downloading it from a GitHub release page.

I also formatted our YAML files.