### PR TITLE
Scheduled workflow to keep the cache alive

### DIFF
--- a/.github/workflows/keep-cache-alive.yml
+++ b/.github/workflows/keep-cache-alive.yml
@@ -1,0 +1,36 @@
+name: Keep cache alive
+
+on:
+  schedule:
+    # run every day at midnight
+    - cron: "0 0 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: sh scripts/install.sh
+      - name: Cache models
+        id: cache-models
+        uses: actions/cache@v3
+        with:
+          path: tests/models
+          key: update-2023-11-29
+      - run: pytest tests
+      - name: Remove models downloaded from GitHub
+        run: |
+          touch tests/_github_files.txt
+          echo "Files removed from cache:"
+          cat tests/_github_files.txt
+          xargs rm < tests/_github_files.txt
+

--- a/.github/workflows/keep-cache-alive.yml
+++ b/.github/workflows/keep-cache-alive.yml
@@ -28,9 +28,5 @@ jobs:
           key: update-2023-11-29
       - run: pytest tests
       - name: Remove models downloaded from GitHub
-        run: |
-          touch tests/_github_files.txt
-          echo "Files removed from cache:"
-          cat tests/_github_files.txt
-          xargs rm < tests/_github_files.txt
+        run: python scripts/remove_github_files.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,7 @@ jobs:
           key: update-2023-11-29
       - run: pytest tests
       - name: Remove models downloaded from GitHub
-        run: |
-          touch tests/_github_files.txt
-          echo "Files removed from cache:"
-          cat tests/_github_files.txt
-          xargs rm < tests/_github_files.txt
+        run: python scripts/remove_github_files.py
 
   docs:
     runs-on: ubuntu-latest

--- a/scripts/remove_github_files.py
+++ b/scripts/remove_github_files.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def main():
+    github_file_log = Path("tests/_github_files.txt").resolve()
+
+    if not github_file_log.exists():
+        print("No _github_files.txt file found")
+        return
+
+    lines = list(filter(bool, github_file_log.read_text().splitlines()))
+    print(f"Removing {len(lines)} files...")
+    for line in lines:
+        file = Path(line)
+        if file.exists():
+            file.unlink()
+            print(f"Removed {file}")
+        else:
+            print(f"File not found: {file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
GitHub removed unused caches after one week of last access. This is a problem for us when we don't commit for a while, because it means that subsequent test runs are a lot slower and more likely to fail.

This PR adds a scheduled workflow that runs our tests every day. This ensures that the cache is always accessed.