### PR TITLE
No `print` in architecture code

### DIFF
--- a/libs/spandrel/spandrel/architectures/GRL/arch/grl.py
+++ b/libs/spandrel/spandrel/architectures/GRL/arch/grl.py
@@ -555,21 +555,3 @@ class GRL(nn.Module):
         x = x / self.img_range + self.mean
 
         return x[:, :, : H * self.upscale, : W * self.upscale]
-
-    def flops(self):
-        pass
-
-    def convert_checkpoint(self, state_dict):
-        for k in list(state_dict.keys()):
-            if (
-                k.find("relative_coords_table") >= 0
-                or k.find("relative_position_index") >= 0
-                or k.find("attn_mask") >= 0
-                or k.find("model.table_") >= 0
-                or k.find("model.index_") >= 0
-                or k.find("model.mask_") >= 0
-                # or k.find(".upsample.") >= 0
-            ):
-                state_dict.pop(k)
-                print(k)
-        return state_dict

--- a/libs/spandrel/spandrel/architectures/Uformer/arch/Uformer.py
+++ b/libs/spandrel/spandrel/architectures/Uformer/arch/Uformer.py
@@ -53,7 +53,6 @@ class FastLeFF(nn.Module):
         flops += H * W * self.hidden_dim * 3 * 3
         # fc2
         flops += H * W * self.hidden_dim * self.dim
-        print("LeFF:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -418,7 +417,6 @@ class SepConv2d(torch.nn.Module):
         flops = 0
         flops += HW * self.in_channels * self.kernel_size**2 / self.stride**2
         flops += HW * self.in_channels * self.out_channels
-        print("SeqConv2d:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -628,7 +626,6 @@ class WindowAttention(nn.Module):
 
         # x = self.proj(x)
         flops += nW * N * self.dim * self.dim
-        print("W-MSA:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -711,7 +708,6 @@ class Attention(nn.Module):
 
         # x = self.proj(x)
         flops += q_num * self.dim * self.dim
-        print("MCA:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -751,7 +747,6 @@ class Mlp(nn.Module):
         flops += H * W * self.in_features * self.hidden_features
         # fc2
         flops += H * W * self.hidden_features * self.out_features
-        print("MLP:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -806,7 +801,6 @@ class LeFF(nn.Module):
         flops += H * W * self.hidden_dim * 3 * 3
         # fc2
         flops += H * W * self.hidden_dim * self.dim
-        print("LeFF:{%.2f}" % (flops / 1e9))
         # eca
         if hasattr(self.eca, "flops"):
             flops += self.eca.flops()
@@ -882,7 +876,6 @@ class Downsample(nn.Module):
         flops = 0
         # conv
         flops += H / 2 * W / 2 * self.in_channel * self.out_channel * 4 * 4
-        print("Downsample:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -908,7 +901,6 @@ class Upsample(nn.Module):
         flops = 0
         # conv
         flops += H * 2 * W * 2 * self.in_channel * self.out_channel * 2 * 2
-        print("Upsample:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -954,7 +946,6 @@ class InputProj(nn.Module):
 
         if self.norm is not None:
             flops += H * W * self.out_channel
-        print("Input_proj:{%.2f}" % (flops / 1e9))
         return flops
 
 
@@ -1005,7 +996,6 @@ class OutputProj(nn.Module):
 
         if self.norm is not None:
             flops += H * W * self.out_channel
-        print("Output_proj:{%.2f}" % (flops / 1e9))
         return flops
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ src = ["libs/spandrel", "libs/spandrel_extra_arches"]
 lint.extend-select = [
     "ANN001",
     "ANN002",
+    "T201",   # no print
     "B",      # bugbear
     "C4",     # comprehensions
     "E",      # pycodestyle
@@ -32,7 +33,7 @@ lint.ignore = [
 [tool.ruff.lint.per-file-ignores]
 "**/__arch_helpers/**/*" = ["N", "ANN"]
 "**/arch/**/*" = ["B006", "B007", "B008", "N", "ANN", "SIM102", "SIM114"]
-"**/tests/**/*" = ["N802", "ANN"]
+"**/{tests,scripts}/**/*" = ["N802", "ANN", "T201"]
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning", "ignore::UserWarning"]


### PR DESCRIPTION
I added a ruff rule to disallow `print` in architecture code. Architecture code should be doing any logging anyway.