### PR TITLE
Unify logic for detecting pixelshuffle

### DIFF
--- a/libs/spandrel/spandrel/architectures/ATD/__init__.py
+++ b/libs/spandrel/spandrel/architectures/ATD/__init__.py
@@ -2,7 +2,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -114,15 +114,7 @@ class ATDArch(Architecture[ATD]):
             upscale = 4
         elif "conv_before_upsample.0.weight" in state_dict:
             upsampler = "pixelshuffle"
-            upscale = 1
-            for i in range(0, 10, 2):
-                if f"upsample.{i}.weight" not in state_dict:
-                    break
-                num_feat = state_dict[f"upsample.{i}.weight"].shape[1]
-
-                upscale *= math.isqrt(
-                    state_dict[f"upsample.{i}.weight"].shape[0] // num_feat
-                )
+            upscale, _ = get_pixelshuffle_params(state_dict, "upsample")
         elif "conv_last.weight" in state_dict:
             upsampler = ""
             upscale = 1

--- a/libs/spandrel/spandrel/architectures/DAT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/DAT/__init__.py
@@ -2,7 +2,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -107,11 +107,7 @@ class DATArch(Architecture[DAT]):
         resi_connection = "1conv" if "conv_after_body.weight" in state_dict else "3conv"
 
         if upsampler == "pixelshuffle":
-            upscale = 1
-            for i in range(0, get_seq_len(state_dict, "upsample"), 2):
-                num_feat = state_dict[f"upsample.{i}.weight"].shape[1]
-                shape = state_dict[f"upsample.{i}.weight"].shape[0]
-                upscale *= int(math.sqrt(shape // num_feat))
+            upscale, num_feat = get_pixelshuffle_params(state_dict, "upsample")
         elif upsampler == "pixelshuffledirect":
             num_feat = state_dict["upsample.0.weight"].shape[1]
             upscale = int(

--- a/libs/spandrel/spandrel/architectures/DRCT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/DRCT/__init__.py
@@ -2,7 +2,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -11,23 +11,6 @@ from ...__helpers.model_descriptor import (
     StateDict,
 )
 from .arch.drct_arch import DRCT
-
-
-def _get_upscale_pixelshuffle(
-    state_dict: StateDict, key_prefix: str = "upsample"
-) -> int:
-    upscale = 1
-
-    for i in range(0, 10, 2):
-        key = f"{key_prefix}.{i}.weight"
-        if key not in state_dict:
-            break
-
-        shape = state_dict[key].shape
-        num_feat = shape[1]
-        upscale *= math.isqrt(shape[0] // num_feat)
-
-    return upscale
 
 
 class DRCTArch(Architecture[DRCT]):
@@ -105,7 +88,7 @@ class DRCTArch(Architecture[DRCT]):
 
         if "conv_last.weight" in state_dict:
             upsampler = "pixelshuffle"
-            upscale = _get_upscale_pixelshuffle(state_dict, "upsample")
+            upscale, _ = get_pixelshuffle_params(state_dict, "upsample")
         else:
             upsampler = ""
             upscale = 1

--- a/libs/spandrel/spandrel/architectures/HAT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/HAT/__init__.py
@@ -2,7 +2,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -109,10 +109,7 @@ class HATArch(Architecture[HAT]):
         embed_dim = state_dict["conv_first.weight"].shape[0]
 
         num_feat = state_dict["conv_last.weight"].shape[1]
-        upscale = 1
-        for i in range(0, get_seq_len(state_dict, "upsample"), 2):
-            shape = state_dict[f"upsample.{i}.weight"].shape[0]
-            upscale *= int(math.sqrt(shape // num_feat))
+        upscale, _ = get_pixelshuffle_params(state_dict, "upsample", num_feat)
 
         window_size = int(math.sqrt(state_dict["relative_position_index_SA"].shape[0]))
         overlap_ratio = _get_overlap_ratio(

--- a/libs/spandrel/spandrel/architectures/RGT/__init__.py
+++ b/libs/spandrel/spandrel/architectures/RGT/__init__.py
@@ -4,7 +4,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -133,13 +133,7 @@ class RGTArch(Architecture[RGT]):
                 )
                 break
 
-        upscale = 1
-        for i in range(0, 10, 2):
-            key = f"upsample.{i}.weight"
-            if key in state_dict:
-                shape = state_dict[key].shape
-                num_feat = shape[1]
-                upscale *= math.isqrt(shape[0] // num_feat)
+        upscale, _ = get_pixelshuffle_params(state_dict, "upsample")
 
         split_size = _get_split_size(state_dict)
 

--- a/libs/spandrel/spandrel/architectures/Swin2SR/__init__.py
+++ b/libs/spandrel/spandrel/architectures/Swin2SR/__init__.py
@@ -2,7 +2,7 @@ import math
 
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -102,11 +102,7 @@ class Swin2SRArch(Architecture[Swin2SR]):
                 math.sqrt(state_dict["upsample.0.weight"].shape[0] // in_chans)
             )
         else:
-            num_feat = 64  # hard-coded constant
-            upscale = 1
-            for i in range(0, get_seq_len(state_dict, "upsample"), 2):
-                shape = state_dict[f"upsample.{i}.weight"].shape[0]
-                upscale *= int(math.sqrt(shape // num_feat))
+            upscale, _ = get_pixelshuffle_params(state_dict, "upsample")
 
         window_size = int(
             math.sqrt(

--- a/libs/spandrel/spandrel/architectures/SwinIR/__init__.py
+++ b/libs/spandrel/spandrel/architectures/SwinIR/__init__.py
@@ -3,7 +3,7 @@ import math
 from torch import nn
 from typing_extensions import override
 
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from ...__helpers.model_descriptor import (
     Architecture,
@@ -84,15 +84,7 @@ class SwinIRArch(Architecture[SwinIR]):
             for _upsample_key in upsample_keys:
                 upscale *= 2
         elif upsampler == "pixelshuffle":
-            upsample_keys = [
-                x
-                for x in state_dict
-                if "upsample" in x and "conv" not in x and "bias" not in x
-            ]
-            for upsample_key in upsample_keys:
-                shape = state_dict[upsample_key].shape[0]
-                upscale *= math.sqrt(shape // num_feat)
-            upscale = int(upscale)
+            upscale, num_feat = get_pixelshuffle_params(state_dict, "upsample")
         elif upsampler == "pixelshuffledirect":
             upscale = int(
                 math.sqrt(state_dict["upsample.0.bias"].shape[0] // num_out_ch)

--- a/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/SRFormer/__init__.py
+++ b/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/SRFormer/__init__.py
@@ -8,7 +8,7 @@ from spandrel import (
     SizeRequirements,
     StateDict,
 )
-from spandrel.util import KeyCondition, get_seq_len
+from spandrel.util import KeyCondition, get_pixelshuffle_params, get_seq_len
 
 from .arch.SRFormer import SRFormer
 
@@ -76,12 +76,7 @@ class SRFormerArch(Architecture[SRFormer]):
             upscale = 4  # only supported scale
         elif "conv_before_upsample.0.weight" in state_dict:
             upsampler = "pixelshuffle"
-
-            num_feat = 64  # hard-coded constant
-            upscale = 1
-            for i in range(0, get_seq_len(state_dict, "upsample"), 2):
-                shape = state_dict[f"upsample.{i}.weight"].shape[0]
-                upscale *= int(math.sqrt(shape // num_feat))
+            upscale, _ = get_pixelshuffle_params(state_dict, "upsample")
         elif "upsample.0.weight" in state_dict:
             upsampler = "pixelshuffledirect"
             upscale = int(


### PR DESCRIPTION
[SwinIR-like `Upsample`](https://github.com/chaiNNer-org/spandrel/blob/fc4bdc03ea3bc291f3f84577b8f8a9004ef6c85d/libs/spandrel/spandrel/architectures/SwinIR/arch/SwinIR.py#L738) is fairly common, because many architectures derive some of their code from SwinIR. This PR adds a util method to detect the parameters of `Upsample` and replaces the same logic in many arches with calls to the util function.