### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/libs/spandrel/spandrel/__init__.py
+++ b/libs/spandrel/spandrel/__init__.py
@@ -2,7 +2,7 @@
 Spandrel is a library for loading and running pre-trained PyTorch models. It automatically detects the model architecture and hyper parameters from model files, and provides a unified interface for running models.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from .__helpers.canonicalize import canonicalize_state_dict
 from .__helpers.loader import ModelLoader

--- a/libs/spandrel_extra_arches/pyproject.toml
+++ b/libs/spandrel_extra_arches/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "spandrel>=0.3.0",
+    "spandrel>=0.3.2",
     "torch",
     "torchvision",
     "numpy",


### PR DESCRIPTION
I also increased the minimum version of spandrel to 0.3.2, because `spandrel_extra_arches` needs the new util method from #249.

Since I want to make a release, I'm just going to merge this of CI passes.