### PR TITLE
Simplified PLKSR

### DIFF
--- a/libs/spandrel/spandrel/architectures/PLKSR/__init__.py
+++ b/libs/spandrel/spandrel/architectures/PLKSR/__init__.py
@@ -54,8 +54,6 @@ class PLKSRArch(Architecture[_PLKSR]):
 
         use_ea = "feats.1.attn.f.0.weight" in state_dict
 
-        tags = [f"{dim}dim", f"{n_blocks}nb", f"{kernel_size}ks"]
-
         # Yes, the normal version has this typo.
         if "feats.1.channe_mixer.0.weight" in state_dict:
             n_blocks = total_feat_layers - 2
@@ -70,7 +68,7 @@ class PLKSRArch(Architecture[_PLKSR]):
                 ccm_type = "ICCM"
             else:
                 raise ValueError("Unknown CCM type")
-            tags.append(ccm_type)
+            more_tags = [ccm_type]
 
             model = PLKSR(
                 dim=dim,
@@ -83,7 +81,8 @@ class PLKSRArch(Architecture[_PLKSR]):
             )
         # and RealPLKSR doesn't. This makes it really convenient to detect.
         elif "feats.1.channel_mixer.0.weight" in state_dict:
-            tags.append("Real")
+            more_tags = ["Real"]
+
             n_blocks = total_feat_layers - 3
             model = RealPLKSR(
                 dim=dim,
@@ -103,7 +102,7 @@ class PLKSRArch(Architecture[_PLKSR]):
             state_dict,
             architecture=self,
             purpose="Restoration" if scale == 1 else "SR",
-            tags=tags,
+            tags=[f"{dim}dim", f"{n_blocks}nb", f"{kernel_size}ks", *more_tags],
             supports_half=False,
             supports_bfloat16=True,
             scale=scale,

--- a/tests/__snapshots__/test_PLKSR.ambr
+++ b/tests/__snapshots__/test_PLKSR.ambr
@@ -9,12 +9,12 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
       '64dim',
-      '28nb',
+      '12nb',
       '13ks',
       'DCCM',
     ]),
@@ -31,7 +31,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -53,7 +53,7 @@
     output_channels=3,
     purpose='SR',
     scale=3,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -75,7 +75,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -97,7 +97,7 @@
     output_channels=3,
     purpose='SR',
     scale=2,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([
@@ -119,7 +119,7 @@
     output_channels=3,
     purpose='SR',
     scale=4,
-    size_requirements=SizeRequirements(minimum=1, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=0, multiple_of=1, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([


### PR DESCRIPTION
I wanted to make review comments, but there was a lot of small things, so I just quickly did them myself.

In general, I made the code less defensive. You almost always checked whether a key was present in the state dict before accessing it. This is entirely unnecessary, because we assume that the state dicts `load` gets are valid. So they aren't missing any important keys. If they were missing any such keys, then they'd be invalid and we'd be allowed to just fail.
Using this assumption, I simplified some code.

Other changes:
- Fixed a bug where the tag for `n_blocks` as create before the real value was assigned.
- Removed size requirement, because it allowed all image sizes.