### PR TITLE
Auto-calculate total model bytes on model descriptor

### DIFF
--- a/libs/spandrel/spandrel/__helpers/model_descriptor.py
+++ b/libs/spandrel/spandrel/__helpers/model_descriptor.py
@@ -214,6 +214,11 @@ class ModelBase(ABC, Generic[T]):
         on how to best use the model.
         """
 
+        self.model_bytes: int = sum(p.numel() * 4 for p in model.parameters())
+        """
+        The number of bytes the model uses in fp32.
+        """
+
         self.model.load_state_dict(state_dict)  # type: ignore
 
     @property


### PR DESCRIPTION
I noticed when profiling chaiNNer we take up a little bit of time every upscale to sum up the total bytes of the model. This only actually needs to be done once (when the model is instantiated), and I figured I could just do it here so it's available on the model descriptor of every model.