### PR TITLE
Only call .eval if training

### DIFF
--- a/libs/spandrel/spandrel/__helpers/model_descriptor.py
+++ b/libs/spandrel/spandrel/__helpers/model_descriptor.py
@@ -465,7 +465,8 @@ class ImageModelDescriptor(ModelBase[T], Generic[T]):
         did_pad, image = pad_tensor(image, self.size_requirements)
 
         # Optimize for inference
-        self.model.eval()
+        if self.model.training:
+            self.model.eval()
 
         # call model
         output = self._call_fn(self.model, image)


### PR DESCRIPTION
Turns out, calling .eval isn't a noop. It takes a very small amount of time to do what it does (under 1ms), but it still does it every time. We can save this op by just checking if the model is in training mode first. If it is, then we can .eval it. If it isn't, we can save this.