### PR TITLE
Add detection for PLKSR's `lk_type` parameter

### DIFF
--- a/libs/spandrel/spandrel/architectures/PLKSR/__init__.py
+++ b/libs/spandrel/spandrel/architectures/PLKSR/__init__.py
@@ -86,7 +86,7 @@ class PLKSRArch(Architecture[_PLKSR]):
                 split_ratio = state_dict["feats.1.lk.convs.0.weight"].shape[0] / dim
                 # Detecting other parameters for SparsePLKConv2d is praticaly impossible.
                 # We cannot detect the values of sparse_dilations at all, we only know it has the same length as sparse_kernels.
-                # Detecting the values of sparse_kernels is possible, but we don't know it's length exactly, because it's `len(sparse_kernels) = len(convs) - (1 if use_max_kernel else 0)`.
+                # Detecting the values of sparse_kernels is possible, but we don't know its length exactly, because it's `len(sparse_kernels) = len(convs) - (1 if use_max_kernel else 0)`.
                 # However, we cannot detect use_max_kernel, because the convolutions it adds when enabled look the same as the other convolutions.
                 # So I give up.
             elif "feats.1.lk.mn_conv.weight" in state_dict:

--- a/tests/test_PLKSR.py
+++ b/tests/test_PLKSR.py
@@ -16,6 +16,7 @@ skip_if_unchanged(__file__)
 def test_load():
     assert_loads_correctly(
         PLKSRArch(),
+        # PLKSR
         lambda: PLKSR(),
         lambda: PLKSR(dim=32),
         lambda: PLKSR(dim=96),
@@ -26,11 +27,18 @@ def test_load():
         lambda: PLKSR(ccm_type="DCCM"),
         lambda: PLKSR(ccm_type="CCM"),
         lambda: PLKSR(ccm_type="ICCM"),
-        lambda: PLKSR(kernel_size=9),
-        lambda: PLKSR(kernel_size=27),
-        lambda: PLKSR(split_ratio=0.5),
-        lambda: PLKSR(split_ratio=0.75),
+        lambda: PLKSR(lk_type="PLK", kernel_size=9),
+        lambda: PLKSR(lk_type="PLK", kernel_size=27),
+        lambda: PLKSR(lk_type="PLK", split_ratio=0.5),
+        lambda: PLKSR(lk_type="PLK", split_ratio=0.75),
+        lambda: PLKSR(lk_type="RectSparsePLK", kernel_size=9),
+        lambda: PLKSR(lk_type="RectSparsePLK", kernel_size=27),
+        lambda: PLKSR(lk_type="RectSparsePLK", split_ratio=0.5),
+        lambda: PLKSR(lk_type="RectSparsePLK", split_ratio=0.75),
+        lambda: PLKSR(lk_type="SparsePLK", split_ratio=0.5),
+        lambda: PLKSR(lk_type="SparsePLK", split_ratio=0.75),
         lambda: PLKSR(use_ea=False),
+        # RealPLKSR
         lambda: RealPLKSR(),
         lambda: RealPLKSR(dim=32),
         lambda: RealPLKSR(dim=96),


### PR DESCRIPTION
Fixes #256.

Detecting parameters for `lk_type="SparsePLK"` turned out to be close to impossible. We can derive some information, but we'd have to make assumptions to get actual values for hyperparameters. Since I don't know what assumptions we can/should make, I just didn't detect anything.

I also shuffled some code around.