### PR TITLE
Restore training conditionals for PLKSR, RealPLKSR, SPAN

### DIFF
--- a/libs/spandrel/spandrel/architectures/PLKSR/arch/PLKSR.py
+++ b/libs/spandrel/spandrel/architectures/PLKSR/arch/PLKSR.py
@@ -64,11 +64,19 @@ class PLKConv2d(nn.Module):
         self.idx = dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.with_idt:
-            x[:, : self.idx] = x[:, : self.idx] + self.conv(x[:, : self.idx])
+        if self.training:
+            x1, x2 = torch.split(x, [self.idx, x.size(1) - self.idx], dim=1)
+            if self.with_idt:
+                x1 = self.conv(x1) + x1
+            else:
+                x1 = self.conv(x1)
+            return torch.cat([x1, x2], dim=1)
         else:
-            x[:, : self.idx] = self.conv(x[:, : self.idx])
-        return x
+            if self.with_idt:
+                x[:, : self.idx] = x[:, : self.idx] + self.conv(x[:, : self.idx])
+            else:
+                x[:, : self.idx] = self.conv(x[:, : self.idx])
+            return x
 
 
 class RectSparsePLKConv2d(nn.Module):

--- a/libs/spandrel/spandrel/architectures/PLKSR/arch/RealPLKSR.py
+++ b/libs/spandrel/spandrel/architectures/PLKSR/arch/RealPLKSR.py
@@ -29,6 +29,10 @@ class PLKConv2d(nn.Module):
         self.idx = dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.training:
+            x1, x2 = torch.split(x, [self.idx, x.size(1) - self.idx], dim=1)
+            x1 = self.conv(x1)
+            return torch.cat([x1, x2], dim=1)
         x[:, : self.idx] = self.conv(x[:, : self.idx])
         return x
 
@@ -109,7 +113,9 @@ class RealPLKSR(nn.Module):
         dropout: float = 0,
     ):
         super().__init__()
-        dropout = 0
+
+        if not self.training:
+            dropout = 0
 
         self.feats = nn.Sequential(
             *[nn.Conv2d(3, dim, 3, 1, 1)]

--- a/libs/spandrel/spandrel/architectures/SPAN/arch/span.py
+++ b/libs/spandrel/spandrel/architectures/SPAN/arch/span.py
@@ -145,9 +145,11 @@ class Conv3XC(nn.Module):
             stride=s,
             bias=bias,
         )
-        self.eval_conv.weight.requires_grad = False
-        self.eval_conv.bias.requires_grad = False  # type: ignore
-        self.update_params()
+
+        if not self.training:
+            self.eval_conv.weight.requires_grad = False
+            self.eval_conv.bias.requires_grad = False  # type: ignore
+            self.update_params()
 
     def update_params(self):
         w1 = self.conv[0].weight.data.clone().detach()


### PR DESCRIPTION
I'm importing spandrel's architecture definitions to train models in traiNNer-redux, and noticed that a few of the architectures in spandrel removed some conditionals involving `self.training`. This PR restores those conditionals. I checked all archs in spandrel against their official versions and these are the only ones I found which were missing `self.training` conditionals.

- PLKSR
  - https://github.com/dslisleedh/PLKSR/blob/968540c952e6818ce6ae7d6d8f9f6b2e0ad669a1/plksr/archs/plksr_arch.py#L70
  - https://github.com/dslisleedh/PLKSR/blob/968540c952e6818ce6ae7d6d8f9f6b2e0ad669a1/plksr/archs/plksr_arch.py#L113
- RealPLKSR
  - https://github.com/muslll/neosr/blob/6e827cb3cf5dd716aa1a2f492962de56ab4dafd5/neosr/archs/realplksr_arch.py#L35
  - https://github.com/muslll/neosr/blob/6e827cb3cf5dd716aa1a2f492962de56ab4dafd5/neosr/archs/realplksr_arch.py#L122
- SPAN
  - https://github.com/hongyuanyu/SPAN/blob/main/basicsr/archs/span_arch.py

Note that the change to SPAN isn't part of the official code, but training with the official SPAN code results in this issue: https://github.com/hongyuanyu/SPAN/issues/4 The change appears to be a safe fix, since the logic is unchanged in inference mode, models trained with this change are still compatible with this arch, and all tests are passing. Let me know if this change needs to be backed out. 