### PR TITLE
Fix NumPy v2 incompatible with OpenCV in tests

### DIFF
--- a/libs/spandrel/spandrel/architectures/Compact/arch/SRVGG.py
+++ b/libs/spandrel/spandrel/architectures/Compact/arch/SRVGG.py
@@ -5,6 +5,8 @@ import torch.nn.functional as F
 
 from spandrel.util import store_hyperparameters
 
+# change
+
 
 @store_hyperparameters()
 class SRVGGNetCompact(nn.Module):

--- a/libs/spandrel/spandrel/architectures/Compact/arch/SRVGG.py
+++ b/libs/spandrel/spandrel/architectures/Compact/arch/SRVGG.py
@@ -5,8 +5,6 @@ import torch.nn.functional as F
 
 from spandrel.util import store_hyperparameters
 
-# change
-
 
 @store_hyperparameters()
 class SRVGGNetCompact(nn.Module):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pyright==1.1.342
 # test
 pytest==7.4.0
 syrupy==4.6.0
-numpy==1.26.4 # opencv needs a 1.x version of Numpy
+numpy==1.24.4 # opencv needs a 1.x version of Numpy
 opencv-python==4.8.1.78
 requests
 beautifulsoup4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pyright==1.1.342
 # test
 pytest==7.4.0
 syrupy==4.6.0
+numpy==1.26.4
 opencv-python==4.8.1.78
 requests
 beautifulsoup4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pyright==1.1.342
 # test
 pytest==7.4.0
 syrupy==4.6.0
-numpy==1.26.4
+numpy==1.26.4 # opencv needs a 1.x version of Numpy
 opencv-python==4.8.1.78
 requests
 beautifulsoup4


### PR DESCRIPTION
Our CI failed, because the version of OpenCV we're using in tests in incompatible with NumPy 2.0, so I downgraded to the last 1.x version of NumPy for tests.