### PR TITLE
Fixed input channels and size req of LaMa

### DIFF
--- a/libs/spandrel/spandrel/architectures/LaMa/__init__.py
+++ b/libs/spandrel/spandrel/architectures/LaMa/__init__.py
@@ -49,7 +49,7 @@ class LaMaArch(Architecture[LaMa]):
             tags=[],
             supports_half=False,
             supports_bfloat16=True,
-            input_channels=in_nc,
+            input_channels=in_nc - 1,
             output_channels=out_nc,
-            size_requirements=SizeRequirements(minimum=16),
+            size_requirements=SizeRequirements(minimum=16, multiple_of=8),
         )

--- a/tests/__snapshots__/test_LaMa.ambr
+++ b/tests/__snapshots__/test_LaMa.ambr
@@ -5,11 +5,11 @@
       id='LaMa',
       name='LaMa',
     ),
-    input_channels=4,
+    input_channels=3,
     output_channels=3,
     purpose='Inpainting',
     scale=1,
-    size_requirements=SizeRequirements(minimum=16, multiple_of=1, square=False),
+    size_requirements=SizeRequirements(minimum=16, multiple_of=8, square=False),
     supports_bfloat16=True,
     supports_half=False,
     tags=list([

--- a/tests/test_LaMa.py
+++ b/tests/test_LaMa.py
@@ -1,6 +1,12 @@
 from spandrel.architectures.LaMa import LaMa, LaMaArch
 
-from .util import ModelFile, assert_loads_correctly, disallowed_props, skip_if_unchanged
+from .util import (
+    ModelFile,
+    assert_loads_correctly,
+    assert_size_requirements,
+    disallowed_props,
+    skip_if_unchanged,
+)
 
 skip_if_unchanged(__file__)
 
@@ -13,6 +19,13 @@ def test_load():
         lambda: LaMa(out_nc=1),
         lambda: LaMa(in_nc=1, out_nc=1),
     )
+
+
+def test_size_requirements():
+    file = ModelFile.from_url(
+        "https://github.com/Sanster/models/releases/download/add_big_lama/big-lama.pt"
+    )
+    assert_size_requirements(file.load_model())
 
 
 def test_LaMa(snapshot):

--- a/tests/util.py
+++ b/tests/util.py
@@ -581,17 +581,21 @@ def assert_size_requirements(
     max_size: int = 64,
     max_candidates: int = 8,
 ) -> None:
-    assert isinstance(model, ImageModelDescriptor)
-
     device = get_test_device()
 
     def test_size(width: int, height: int) -> None:
         try:
-            input_tensor = torch.rand(1, model.input_channels, height, width)
+            input_tensor = torch.rand(
+                1, model.input_channels, height, width, device=device
+            )
             model.to(device).eval()
 
             with torch.no_grad():
-                output_tensor = model(input_tensor.to(device))
+                if isinstance(model, ImageModelDescriptor):
+                    output_tensor = model(input_tensor)
+                else:
+                    mask = torch.rand(1, 1, height, width, device=device).round_()
+                    output_tensor = model(input_tensor, mask)
 
             expected_shape = (
                 1,
@@ -603,6 +607,7 @@ def assert_size_requirements(
                 output_tensor.shape == expected_shape
             ), f"Expected {expected_shape}, but got {output_tensor.shape}"
         except Exception as e:
+            print(str(e))
             raise AssertionError(
                 f"Failed size requirement test for {width=} {height=}"
             ) from e

--- a/tests/util.py
+++ b/tests/util.py
@@ -607,7 +607,6 @@ def assert_size_requirements(
                 output_tensor.shape == expected_shape
             ), f"Expected {expected_shape}, but got {output_tensor.shape}"
         except Exception as e:
-            print(str(e))
             raise AssertionError(
                 f"Failed size requirement test for {width=} {height=}"
             ) from e


### PR DESCRIPTION
Changes:
- Fixed input channels of LaMa.
- Fixed the size requirements of LaMa. Only multiples of 8 are supported.
- Made `assert_size_requirements` compatible with masked image models.