### PR TITLE
Include source distributions

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,11 +5,11 @@ set -e
 # spandrel
 cp README.md libs/spandrel/README.md
 cd libs/spandrel
-python3 -m build . --wheel
+python3 -m build .
 rm README.md
 cd ../..
 
 # spandrel_extra_arches
 cd libs/spandrel_extra_arches
-python3 -m build . --wheel
+python3 -m build .
 cd ../..


### PR DESCRIPTION
Fixes #273

Turns out, `python3 -m build .` already builds both a source and binary distribution. By passing the `--wheel` flag, we disabled the source distribution.