### PR TITLE
Fixed that MAT cannot load its own models

### DIFF
--- a/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/MAT/__init__.py
+++ b/libs/spandrel_extra_arches/spandrel_extra_arches/architectures/MAT/__init__.py
@@ -15,8 +15,9 @@ class MATArch(Architecture[MAT]):
     def __init__(self) -> None:
         super().__init__(
             id="MAT",
-            detect=KeyCondition.has_all(
+            detect=KeyCondition.has_any(
                 "synthesis.first_stage.conv_first.conv.resample_filter",
+                "model.synthesis.first_stage.conv_first.conv.resample_filter",
             ),
         )
 
@@ -25,12 +26,12 @@ class MATArch(Architecture[MAT]):
         in_nc = 3
         out_nc = 3
 
-        state = {
-            k.replace("synthesis", "model.synthesis").replace(
-                "mapping", "model.mapping"
-            ): v
-            for k, v in state_dict.items()
-        }
+        def map_key(k: str) -> str:
+            if k.startswith(("synthesis.", "mapping.")):
+                return "model." + k
+            return k
+
+        state = {map_key(k): v for k, v in state_dict.items()}
 
         model = MAT()
 

--- a/tests/test_MAT.py
+++ b/tests/test_MAT.py
@@ -1,8 +1,21 @@
-from spandrel_extra_arches.architectures.MAT import MAT
+from spandrel_extra_arches.architectures.MAT import MAT, MATArch
 
-from .util import ModelFile, disallowed_props, skip_if_unchanged
+from .util import (
+    ModelFile,
+    assert_loads_correctly,
+    disallowed_props,
+    skip_if_unchanged,
+)
 
 skip_if_unchanged(__file__)
+
+
+def test_load():
+    assert_loads_correctly(
+        MATArch(),
+        lambda: MAT(),
+        check_safe_tensors=False,
+    )
 
 
 def test_MAT(snapshot):


### PR DESCRIPTION
I noticed that MAT models couldn't be saved and loaded again, so I fixed this.