### PR TITLE
Test model training

### DIFF
--- a/tests/test_ATD.py
+++ b/tests/test_ATD.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -53,6 +54,10 @@ def test_size_requirements():
         name="103_ATD_light_SRx4_finetune.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(ATDArch(), ATD())
 
 
 def test_101_ATD_light_SRx2_scratch(snapshot):

--- a/tests/test_AdaCode.py
+++ b/tests/test_AdaCode.py
@@ -7,6 +7,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     skip_if_unchanged,
 )
 
@@ -48,6 +49,11 @@ def test_size_requirements():
         "https://github.com/kechunl/AdaCode/releases/download/v0-pretrain_models/AdaCode_SR_X4_model_g.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(AdaCodeArch(), AdaCode())
 
 
 def test_AdaCode_SR_X2_model_g(snapshot):

--- a/tests/test_CRAFT.py
+++ b/tests/test_CRAFT.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -49,6 +50,10 @@ def test_size_requirements():
         name="CRAFT_MODEL_X3.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(CRAFTArch(), CRAFT())
 
 
 def test_CRAFT_x2(snapshot):

--- a/tests/test_CodeFormer.py
+++ b/tests/test_CodeFormer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -29,6 +30,11 @@ def test_size_requirements():
     )
     # TODO: this currently doesn't ensure that 1024x1024 is invalid
     assert_size_requirements(file.load_model(), max_size=512)
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(CodeFormerArch(), CodeFormer())
 
 
 def test_CodeFormer(snapshot):

--- a/tests/test_Compact.py
+++ b/tests/test_Compact.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -37,6 +38,10 @@ def test_size_requirements():
         "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/2x-AniScale.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(CompactArch(), Compact())
 
 
 def test_Compact_realesr_general_x4v3(snapshot):

--- a/tests/test_DAT.py
+++ b/tests/test_DAT.py
@@ -7,6 +7,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -46,6 +47,10 @@ def test_size_requirements():
         "https://github.com/OpenModelDB/model-hub/releases/download/dat/4x-DAT_S.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(DATArch(), DAT(), batch_size=2)
 
 
 def test_DAT_S_x4(snapshot):

--- a/tests/test_DCTLSA.py
+++ b/tests/test_DCTLSA.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -34,6 +35,10 @@ def test_size_requirements():
         name="2x_dctlsa.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(DCTLSAArch(), DCTLSA())
 
 
 def test_x4(snapshot):

--- a/tests/test_DDColor.py
+++ b/tests/test_DDColor.py
@@ -5,6 +5,7 @@ from .util import (
     TestImage,
     assert_image_inference,
     assert_loads_correctly,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -61,6 +62,11 @@ def test_load():
         ),
         ignore_parameters={"input_size"},
     )
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(DDColorArch(), DDColor())
 
 
 def test_DDColor_paper_tiny(snapshot):

--- a/tests/test_DITN.py
+++ b/tests/test_DITN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -43,6 +44,10 @@ def test_size_requirements():
         name="DITN_Real_x4.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(DITNArch(), DITN())
 
 
 def test_DITN_Real_GAN_x4(snapshot):

--- a/tests/test_DRCT.py
+++ b/tests/test_DRCT.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -37,6 +38,11 @@ def test_size_requirements():
         "https://github.com/Phhofm/models/releases/download/4xRealWebPhoto_v4_drct-l/4xRealWebPhoto_v4_drct-l.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(DRCTArch(), DRCT())
 
 
 def test_community_model(snapshot):

--- a/tests/test_DRUNet.py
+++ b/tests/test_DRUNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -33,6 +34,10 @@ def test_size_requirements():
         "https://github.com/cszn/KAIR/releases/download/v1.0/drunet_color.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(DRUNetArch(), DRUNet())
 
 
 def test_drunet_color(snapshot):

--- a/tests/test_DnCNN.py
+++ b/tests/test_DnCNN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -27,6 +28,10 @@ def test_size_requirements():
         "https://github.com/cszn/KAIR/releases/download/v1.0/dncnn_color_blind.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(DnCNNArch(), DnCNN())
 
 
 def test_dncnn_color_blind(snapshot):

--- a/tests/test_ESRGAN.py
+++ b/tests/test_ESRGAN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -39,6 +40,10 @@ def test_size_requirements():
         "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(ESRGANArch(), ESRGAN())
 
 
 def test_ESRGAN_community(snapshot):

--- a/tests/test_FBCNN.py
+++ b/tests/test_FBCNN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -39,6 +40,11 @@ def test_size_requirements():
         "https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_gray.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(FBCNNArch(), FBCNN())
 
 
 def test_FBCNN_color(snapshot):

--- a/tests/test_FFTformer.py
+++ b/tests/test_FFTformer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -30,6 +31,10 @@ def test_size_requirements():
         name="fftformer_GoPro.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(FFTformerArch(), FFTformer())
 
 
 def test_fftformer_GoPro(snapshot):

--- a/tests/test_FeMaSR.py
+++ b/tests/test_FeMaSR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -47,6 +48,10 @@ def test_size_requirements():
         "https://github.com/chaofengc/FeMaSR/releases/download/v0.1-pretrain_models/FeMaSR_SRX4_model_g.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(FeMaSRArch(), FeMaSR())
 
 
 def test_FeMaSR_1x(snapshot):

--- a/tests/test_GFPGAN.py
+++ b/tests/test_GFPGAN.py
@@ -5,6 +5,7 @@ from .util import (
     ModelFile,
     TestImage,
     assert_image_inference,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -17,6 +18,11 @@ def test_load():
         GFPGANArch(),
         lambda: GFPGAN(),
     )
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(GFPGANArch(), GFPGAN())
 
 
 def test_GFPGAN_1_2(snapshot):

--- a/tests/test_GRL.py
+++ b/tests/test_GRL.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -133,6 +134,10 @@ def test_size_requirements():
         "https://github.com/ofsoundof/GRL-Image-Restoration/releases/download/v1.0.0/sr_grl_tiny_c3x4.ckpt"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(GRLArch(), GRL())
 
 
 # def test_GRL_dn_grl_tiny_c1(snapshot):

--- a/tests/test_HAT.py
+++ b/tests/test_HAT.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -55,6 +56,11 @@ def test_size_requirements():
         name="HAT_SRx4.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(HATArch(), HAT())
 
 
 def test_HAT_S_2x(snapshot):

--- a/tests/test_HVICIDNet.py
+++ b/tests/test_HVICIDNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -29,6 +30,10 @@ def test_size_requirements():
         name="HVI-CIDNet_lolv1_w_perc.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(HVICIDNetArch(), HVICIDNet())
 
 
 def test_LOLv1(snapshot):

--- a/tests/test_IPT.py
+++ b/tests/test_IPT.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -34,6 +35,10 @@ def test_size_requirements():
         name="IPT_denoise50.pth",
     )
     assert_size_requirements(file.load_model(), max_candidates=4)
+
+
+def test_train():
+    assert_training(IPTArch(), IPT())
 
 
 def test_IPT_denoise50(snapshot):

--- a/tests/test_KBNet.py
+++ b/tests/test_KBNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -47,6 +48,11 @@ def test_size_requirements():
         "https://github.com/OpenModelDB/model-hub/releases/download/kbnet/1x-KBNet_sidd.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(KBNetArch(), KBNet_s())
+    assert_training(KBNetArch(), KBNet_l())
 
 
 def test_derain(snapshot):

--- a/tests/test_M3SNet.py
+++ b/tests/test_M3SNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -35,6 +36,10 @@ def test_size_requirements():
         name="m3snet_deblur_model_best_64.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(M3SNetArch(), M3SNet())
 
 
 def test_deblur_model_best_32(snapshot):

--- a/tests/test_MIRNet2.py
+++ b/tests/test_MIRNet2.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -45,6 +46,10 @@ def test_size_requirements():
         name="MIRNet2_enhancement_lol.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(MIRNet2Arch(), MIRNet2())
 
 
 def test_dual_pixel_defocus_deblurring(snapshot):

--- a/tests/test_MMRealSR.py
+++ b/tests/test_MMRealSR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -80,6 +81,11 @@ def test_size_requirements():
         "https://github.com/TencentARC/MM-RealSR/releases/download/v1.0.0/MMRealSRNet.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(MMRealSRArch(), MMRealSR(num_in_ch=3, num_out_ch=3))
 
 
 def test_MMRealSRGAN(snapshot):

--- a/tests/test_MPRNet.py
+++ b/tests/test_MPRNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -35,6 +36,11 @@ def test_size_requirements():
         name="MPRNet_model_deblurring.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(MPRNetArch(), MPRNet())
 
 
 def test_deblurring(snapshot):

--- a/tests/test_MixDehazeNet.py
+++ b/tests/test_MixDehazeNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -38,6 +39,10 @@ def test_size_requirements():
         name="MixDehazeNet-b indoor.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(MixDehazeNetArch(), MixDehazeNet())
 
 
 def test_b_indoor(snapshot):

--- a/tests/test_NAFNet.py
+++ b/tests/test_NAFNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -39,6 +40,10 @@ def test_size_requirements():
         name="NAFNet-GoPro-width32.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(NAFNetArch(), NAFNet())
 
 
 def test_NAFNet_GoPro_width32(snapshot):

--- a/tests/test_OmniSR.py
+++ b/tests/test_OmniSR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -41,6 +42,10 @@ def test_size_requirements():
         "https://github.com/Phhofm/models/raw/main/2xHFA2kAVCOmniSR/2xHFA2kAVCOmniSR.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(OmniSRArch(), OmniSR())
 
 
 def test_OmniSR_official_x4(snapshot):

--- a/tests/test_PLKSR.py
+++ b/tests/test_PLKSR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -66,6 +67,11 @@ def test_size_requirements():
         name="PLKSR_X2_DIV2K.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(PLKSRArch(), PLKSR())
+    assert_training(PLKSRArch(), RealPLKSR())
 
 
 def test_PLKSR_official_x4(snapshot):

--- a/tests/test_RGT.py
+++ b/tests/test_RGT.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -48,6 +49,10 @@ def test_size_requirements():
         "https://github.com/OpenModelDB/model-hub/releases/download/rgt/4x-RGT.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(RGTArch(), RGT())
 
 
 def test_RGT_x2(snapshot):

--- a/tests/test_RealCUGAN.py
+++ b/tests/test_RealCUGAN.py
@@ -12,6 +12,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -60,6 +61,13 @@ def test_size_requirements():
         name="sudo_shuffle_cugan_9.584.969.pth",
     )
     assert_size_requirements(file.load_model(), max_candidates=128, max_size=128)
+
+
+def test_train():
+    assert_training(RealCUGANArch(), UpCunet2x())
+    assert_training(RealCUGANArch(), UpCunet2x_fast())
+    assert_training(RealCUGANArch(), UpCunet3x())
+    assert_training(RealCUGANArch(), UpCunet4x())
 
 
 def test_RealCUGAN_2x(snapshot):

--- a/tests/test_RestoreFormer.py
+++ b/tests/test_RestoreFormer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -34,6 +35,11 @@ def test_size_requirements():
         "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/RestoreFormer.pth"
     )
     assert_size_requirements(file.load_model(), max_size=128)
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(RestoreFormerArch(), RestoreFormer())
 
 
 def test_RestoreFormer(snapshot):

--- a/tests/test_Restormer.py
+++ b/tests/test_Restormer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -44,6 +45,10 @@ def test_size_requirements():
         name="restormer_motion_deblurring.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(RestormerArch(), Restormer())
 
 
 def test_deraining(snapshot):

--- a/tests/test_RetinexFormer.py
+++ b/tests/test_RetinexFormer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -29,6 +30,10 @@ def test_size_requirements():
         name="retinexFormer_FiveK.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(RetinexFormerArch(), RetinexFormer())
 
 
 def test_FiveK(snapshot):

--- a/tests/test_SAFMN.py
+++ b/tests/test_SAFMN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -40,6 +41,10 @@ def test_size_requirements():
         name="SAFMN_DF2K_x4.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(SAFMNArch(), SAFMN(dim=8))
 
 
 def test_SAFMN_DF2K_x2(snapshot):

--- a/tests/test_SAFMNBCIE.py
+++ b/tests/test_SAFMNBCIE.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -33,6 +34,10 @@ def test_size_requirements():
         "https://github.com/sunny2109/SAFMN/releases/download/v0.1.1/SAFMN_BCIE.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(SAFMNBCIEArch(), SAFMNBCIE(dim=8))
 
 
 def test_SAFMN_BCIE(snapshot):

--- a/tests/test_SCUNet.py
+++ b/tests/test_SCUNet.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -36,6 +37,10 @@ def test_size_requirements():
         "https://github.com/cszn/KAIR/releases/download/v1.0/scunet_color_real_psnr.pth"
     )
     assert_size_requirements(file.load_model(), max_size=128)
+
+
+def test_train():
+    assert_training(SCUNetArch(), SCUNet())
 
 
 def test_SCUNet_color_GAN(snapshot):

--- a/tests/test_SPAN.py
+++ b/tests/test_SPAN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -35,6 +36,10 @@ def test_size_requirements():
         "https://github.com/OpenModelDB/model-hub/releases/download/span/4x-spanx4_ch48.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(SPANArch(), SPAN(num_in_ch=3, num_out_ch=3))
 
 
 def test_SPAN_x4_ch48(snapshot):

--- a/tests/test_SRFormer.py
+++ b/tests/test_SRFormer.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -54,6 +55,11 @@ def test_size_requirements():
         name="SRFormerLight_SRx3_DIV2K.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(SRFormerArch(), SRFormer())
 
 
 def test_SRFormer_SRx2_DF2K(snapshot):

--- a/tests/test_SwiftSRGAN.py
+++ b/tests/test_SwiftSRGAN.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -38,6 +39,10 @@ def test_size_requirements():
         name="swift_srgan_4x.pth",
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    assert_training(SwiftSRGANArch(), SwiftSRGAN())
 
 
 def test_SwiftSRGAN_2x(snapshot):

--- a/tests/test_Swin2SR.py
+++ b/tests/test_Swin2SR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -48,6 +49,11 @@ def test_size_requirements():
         "https://github.com/mv-lab/swin2sr/releases/download/v0.0.1/Swin2SR_Jpeg_dynamic.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(Swin2SRArch(), Swin2SR())
 
 
 def test_Swin2SR_2x(snapshot):

--- a/tests/test_SwinIR.py
+++ b/tests/test_SwinIR.py
@@ -6,6 +6,7 @@ from .util import (
     assert_image_inference,
     assert_loads_correctly,
     assert_size_requirements,
+    assert_training,
     disallowed_props,
     skip_if_unchanged,
 )
@@ -32,6 +33,11 @@ def test_size_requirements():
         "https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/002_lightweightSR_DIV2K_s64w8_SwinIR-S_x2.pth"
     )
     assert_size_requirements(file.load_model())
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(SwinIRArch(), SwinIR())
 
 
 def test_SwinIR_M_s64w8_2x(snapshot):

--- a/tests/test_Uformer.py
+++ b/tests/test_Uformer.py
@@ -1,6 +1,6 @@
 from spandrel.architectures.Uformer import Uformer, UformerArch
 
-from .util import assert_loads_correctly, skip_if_unchanged
+from .util import assert_loads_correctly, assert_training, skip_if_unchanged
 
 skip_if_unchanged(__file__)
 
@@ -28,3 +28,8 @@ def test_load():
         lambda: Uformer(embed_dim=4, modulator=True),
         lambda: Uformer(embed_dim=4, cross_modulator=True),
     )
+
+
+def test_train():
+    # TODO: fix training
+    assert_training(UformerArch(), Uformer())


### PR DESCRIPTION
This adds a util function to test that models can train and uses it to test all image models.

Out of 44 models, 14 fail. I added a TODO comment to all of those. We have to decide how to deal with them.

---

I also noticed that [it's impossible](https://github.com/chaiNNer-org/spandrel/blob/7c1094f37a9a4e90caf5efc6289f38a9c5bf6d3f/libs/spandrel/spandrel/__helpers/model_descriptor.py#L468) to use the call API for training, which is a shame.