### PR TITLE
fix crop output padding for pixel unshuffle esrgan

### DIFF
--- a/libs/spandrel/spandrel/architectures/ESRGAN/__arch/RRDB.py
+++ b/libs/spandrel/spandrel/architectures/ESRGAN/__arch/RRDB.py
@@ -135,9 +135,10 @@ class RRDBNet(nn.Module):
 
     def forward(self, x):
         if self.shuffle_factor:
+            true_scale = self.scale // self.shuffle_factor
             _, _, h, w = x.size()
             x = pad_to_multiple(x, self.shuffle_factor, mode="reflect")
             x = torch.pixel_unshuffle(x, downscale_factor=self.shuffle_factor)
             x = self.model(x)
-            return x[:, :, : h * self.scale, : w * self.scale]
+            return x[:, :, : h * true_scale, : w * true_scale]
         return self.model(x)


### PR DESCRIPTION
For ESRGAN with pixel unshuffle mode, the input is padded and then the output is cropped to ensure the output resolution is correct, but the cropping has a small bug. When using pixel unshuffle `self.scale` is always 4 and the true scale can be recovered with `self.shuffle_factor` (as is done [here](https://github.com/chaiNNer-org/spandrel/blob/a1db3f5debbeeacbe02fb4114c69feee56ba5e21/libs/spandrel/spandrel/architectures/ESRGAN/__init__.py#L218)). 

The existing code does the crop assuming `self.scale` is the true scale, so when the true scale is 1 or 2, the indexes are larger than they should be and no cropping is actually done. This causes the output image to be slightly larger than it should be. 

In practice this doesn't affect much, downstream software like chaiNNer is unaffected since it uses `ImageModelDescriptor` which [performs its own crop](https://github.com/chaiNNer-org/spandrel/blob/a1db3f5debbeeacbe02fb4114c69feee56ba5e21/libs/spandrel/spandrel/__helpers/model_descriptor.py#L482). But it seems like a good idea to fix anyway?