### PR TITLE
feat(pyproject): add project section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+backend-path = ["."]
+
+[project]
+name = "spandrel"
+version = "0.4.1"
+description = "A placeholder description. "
+authors = [
+    {name = "ChaiNNer", email = "chaiNNer@chaiNNer.org"},
+]
+
+[tool.setuptools]
+package-dir = { spandrel = "libs/spandrel/spandrel", spandrel_extra_arches = "libs/spandrel_extra_arches/spandrel_extra_arches" }
+
 [tool.ruff]
 # Same as Black.
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ backend-path = ["."]
 [project]
 name = "spandrel"
 version = "0.4.1"
-description = "A placeholder description. "
+description = "Spandrel is a library for loading and running pre-trained PyTorch models. It automatically detects the model architecture and hyperparameters from model files, and provides a unified interface for running models."
 authors = [
     {name = "ChaiNNer", email = "chaiNNer@chaiNNer.org"},
 ]


### PR DESCRIPTION
to make it work with `uv pip install`
all of pyproject.toml's should have `project` section. pip skips this by setting it to UNKNOWN. but `uv pip install` complains with
```bash
warning: `/Users/vedatbaday/Library/Caches/uv/git-v0/checkouts/51d07ce5f382dd3a/8bbc37c` does not
appear to be a Python project, as the `pyproject.toml` does not include a `[build-system]` table,
and neither `setup.py` nor `setup.cfg` are present in the directory
error: Failed to parse metadata from built wheel
  Caused by: Metadata field Name not found
```

this change will also make it possible to install from upstream sources such as 
```bash
uv pip install git+https://github.com/chaiNNer-org/spandrel.git
```