### PR TITLE
Support `bfloat16` in DAT and HAT

### DIFF
--- a/libs/spandrel/spandrel/architectures/DAT/__arch/DAT.py
+++ b/libs/spandrel/spandrel/architectures/DAT/__arch/DAT.py
@@ -328,12 +328,12 @@ class Adaptive_Spatial_Attention(nn.Module):
         self.patches_resolution = reso
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
 
-        assert (
-            0 <= self.shift_size[0] < self.split_size[0]
-        ), "shift_size must in 0-split_size0"
-        assert (
-            0 <= self.shift_size[1] < self.split_size[1]
-        ), "shift_size must in 0-split_size1"
+        assert 0 <= self.shift_size[0] < self.split_size[0], (
+            "shift_size must in 0-split_size0"
+        )
+        assert 0 <= self.shift_size[1] < self.split_size[1], (
+            "shift_size must in 0-split_size1"
+        )
 
         self.branch_num = 2
 
@@ -389,11 +389,11 @@ class Adaptive_Spatial_Attention(nn.Module):
             nn.Conv2d(dim // 16, 1, kernel_size=1),
         )
 
-    def calculate_mask(self, H, W):
+    def calculate_mask(self, H, W, dtype=None):
         # The implementation builds on Swin Transformer code https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py
         # calculate attention mask for shift window
-        img_mask_0 = torch.zeros((1, H, W, 1))  # 1 H W 1 idx=0
-        img_mask_1 = torch.zeros((1, H, W, 1))  # 1 H W 1 idx=1
+        img_mask_0 = torch.zeros((1, H, W, 1), dtype=dtype)  # 1 H W 1 idx=0
+        img_mask_1 = torch.zeros((1, H, W, 1), dtype=dtype)  # 1 H W 1 idx=1
         h_slices_0 = (
             slice(0, -self.split_size[0]),
             slice(-self.split_size[0], -self.shift_size[0]),
@@ -516,7 +516,7 @@ class Adaptive_Spatial_Attention(nn.Module):
             qkv_1 = qkv_1.view(3, B, _L, C // 2)
 
             if self.patches_resolution != _H or self.patches_resolution != _W:
-                mask_tmp = self.calculate_mask(_H, _W)
+                mask_tmp = self.calculate_mask(_H, _W, dtype=x.dtype)
                 x1_shift = self.attns[0](qkv_0, _H, _W, mask=mask_tmp[0].to(x.device))
                 x2_shift = self.attns[1](qkv_1, _H, _W, mask=mask_tmp[1].to(x.device))
             else:
@@ -863,7 +863,7 @@ class Upsample(nn.Sequential):
             m.append(nn.PixelShuffle(3))
         else:
             raise ValueError(
-                f"scale {scale} is not supported. " "Supported scales: 2^n and 3."
+                f"scale {scale} is not supported. Supported scales: 2^n and 3."
             )
         super().__init__(*m)
 

--- a/libs/spandrel/spandrel/architectures/HAT/__arch/HAT.py
+++ b/libs/spandrel/spandrel/architectures/HAT/__arch/HAT.py
@@ -292,9 +292,9 @@ class HAB(nn.Module):
             # if window size is larger than input resolution, we don't partition windows
             self.shift_size = 0
             self.window_size = min(self.input_resolution)
-        assert (
-            0 <= self.shift_size < self.window_size
-        ), "shift_size must in 0-window_size"
+        assert 0 <= self.shift_size < self.window_size, (
+            "shift_size must in 0-window_size"
+        )
 
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
@@ -818,7 +818,7 @@ class Upsample(nn.Sequential):
             m.append(nn.PixelShuffle(3))
         else:
             raise ValueError(
-                f"scale {scale} is not supported. " "Supported scales: 2^n and 3."
+                f"scale {scale} is not supported. Supported scales: 2^n and 3."
             )
         super().__init__(*m)
 
@@ -1062,10 +1062,10 @@ class HAT(nn.Module):
         relative_position_index = relative_coords.sum(-1)
         return relative_position_index
 
-    def calculate_mask(self, x_size):
+    def calculate_mask(self, x_size, dtype):
         # calculate attention mask for SW-MSA
         h, w = x_size
-        img_mask = torch.zeros((1, h, w, 1))  # 1 h w 1
+        img_mask = torch.zeros((1, h, w, 1), dtype=dtype)  # 1 h w 1
         h_slices = (
             slice(0, -self.window_size),
             slice(-self.window_size, -self.shift_size),
@@ -1101,7 +1101,7 @@ class HAT(nn.Module):
 
         # Calculate attention mask and relative position index in advance to speed up inference.
         # The original code is very time-consuming for large window size.
-        attn_mask = self.calculate_mask(x_size).to(x.device)
+        attn_mask = self.calculate_mask(x_size, dtype=x.dtype).to(x.device)
         params = {
             "attn_mask": attn_mask,
             "rpi_sa": self.relative_position_index_SA,


### PR DESCRIPTION
As it stands, both DAT and HAT do not support `bfloat16` because the attention masks always have `float32` as their `dtype`. This pull request ensures that the masks have the appropriate `dtype`.