### PR TITLE
perf: defer torchvision imports to cut ~770ms off cold import time

### DIFF
--- a/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
+++ b/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
@@ -10,7 +10,6 @@ Model adapted from advimman's lama project: https://github.com/advimman/lama
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchvision.transforms.functional import InterpolationMode, rotate
 
 from spandrel.util import store_hyperparameters
 
@@ -37,6 +36,8 @@ class LearnableSpatialTransformWrapper(nn.Module):
             raise ValueError(f"Unexpected input type {type(x)}")
 
     def transform(self, x):
+        from torchvision.transforms.functional import InterpolationMode, rotate
+
         height, width = x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
         x_padded = F.pad(x, [pad_w, pad_w, pad_h, pad_h], mode="reflect")
@@ -47,6 +48,8 @@ class LearnableSpatialTransformWrapper(nn.Module):
         return x_padded_rotated
 
     def inverse_transform(self, y_padded_rotated, orig_x):
+        from torchvision.transforms.functional import InterpolationMode, rotate
+
         height, width = orig_x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
 

--- a/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
+++ b/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
@@ -1,5 +1,4 @@
 import torch
-from torchvision.transforms.functional import normalize as tv_normalize
 from typing_extensions import override
 
 from spandrel.util import KeyCondition, get_seq_len
@@ -81,6 +80,8 @@ class RestoreFormerArch(Architecture[RestoreFormer]):
             enable_mid=enable_mid,
             head_size=head_size,
         )
+
+        from torchvision.transforms.functional import normalize as tv_normalize
 
         def call(model: RestoreFormer, x: torch.Tensor) -> torch.Tensor:
             x = tv_normalize(x, [0.5, 0.5, 0.5], [0.5, 0.5, 0.5])


### PR DESCRIPTION
## Summary

`import spandrel` currently takes **~1.93s** cold. Of that, **~770ms (~40%)** is wasted on transitive imports triggered by two architecture modules that import `torchvision.transforms.functional` at module scope.

The chain:
```
LaMa/__arch/LaMa.py:  from torchvision.transforms.functional import InterpolationMode, rotate
RestoreFormer/__init__.py:  from torchvision.transforms.functional import normalize as tv_normalize
```
→ `torchvision.transforms.functional` → `torchvision.models.convnext` → `torchvision.ops.poolers` → `torchvision.ops.roi_align` → **`torch._dynamo`** (685ms alone) → sympy, torch.fx.experimental.symbolic_shapes, torch._decomp, ...

`torch._dynamo` is not pulled by plain `import torch` — it only arrives via the `torchvision.ops.roi_align` path. None of spandrel's loading code needs dynamo.

## Fix

Defer both imports into the methods that actually use them:

- `LaMa.py` — `rotate` / `InterpolationMode` only used inside `LearnableSpatialTransformWrapper.transform` / `inverse_transform`.
- `RestoreFormer/__init__.py` — `tv_normalize` only used inside the `call` closure built in `load()`.

After the first call, the import is a `sys.modules` dict hit (~100ns), so no measurable inference cost. RestoreFormer's import runs once at model-load time and is captured by closure.

## Results

| | Before | After |
|---|---|---|
| `import spandrel` (5-run avg) | ~1.93s | **1.16s** |
| `torch._dynamo` in `sys.modules` after import | yes | **no** |

Remaining ~1.08s is `import torch` baseline (unavoidable). Spandrel-only overhead is now ~80ms for 60 architectures.

## Test plan

- [x] `pytest tests/test_LaMa.py tests/test_RestoreFormer.py` — all 6 pass, snapshots match
- [x] Verified `torch._dynamo` no longer loaded after `import spandrel`
- [x] Verified `torchvision` still loads correctly when LaMa / RestoreFormer inference is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)